### PR TITLE
Don't use Coq modules for structs

### DIFF
--- a/internal/coq/coq.go
+++ b/internal/coq/coq.go
@@ -134,9 +134,7 @@ type StructDecl struct {
 func (d StructDecl) CoqDecl() string {
 	var pp buffer
 	pp.AddComment(d.Comment)
-	pp.Add("Module %s.", d.Name)
-	pp.Indent(2)
-	pp.AddLine("Definition S := struct.decl [")
+	pp.Add("Definition %s := struct.decl [", d.Name)
 	pp.Indent(2)
 	for i, fd := range d.Fields {
 		sep := ";"
@@ -148,7 +146,6 @@ func (d StructDecl) CoqDecl() string {
 	pp.Indent(-2)
 	pp.AddLine("].")
 	pp.Indent(-2)
-	pp.Add("End %s.", d.Name)
 	return pp.Build()
 }
 
@@ -158,6 +155,7 @@ type InterfaceDecl struct {
 	Comment string
 }
 
+// FIXME: update these to not use modules
 func (d InterfaceDecl) CoqDecl() string {
 	var pp buffer
 	pp.AddComment(d.Comment)
@@ -250,9 +248,9 @@ func (d StructToInterface) CoqDecl() string {
 		pp.Add("rec: \"%s_to_%s\" \"t\" :=", d.Struct, d.Interface)
 		pp.Indent(2)
 		if len(d.Methods) == 1 {
-			pp.Add("struct.mk %s.S [\"%s\" ::= %s__%s \"t\"].", d.Interface, d.Methods[0], d.Struct, d.Methods[0])
+			pp.Add("struct.mk %s [\"%s\" ::= %s__%s \"t\"].", d.Interface, d.Methods[0], d.Struct, d.Methods[0])
 		} else {
-			pp.Add("struct.mk %s.S [", d.Interface)
+			pp.Add("struct.mk %s [", d.Interface)
 			pp.Indent(2)
 			for i, method := range d.Methods {
 				if i == len(d.Methods)-1 {
@@ -468,7 +466,7 @@ type StructFieldAccessExpr struct {
 }
 
 func StructDesc(name string) Expr {
-	return GallinaIdent(fmt.Sprintf("%s.S", name))
+	return GallinaIdent(name)
 }
 
 func (e StructFieldAccessExpr) Coq() string {

--- a/internal/coq/coq.go
+++ b/internal/coq/coq.go
@@ -155,13 +155,10 @@ type InterfaceDecl struct {
 	Comment string
 }
 
-// FIXME: update these to not use modules
 func (d InterfaceDecl) CoqDecl() string {
 	var pp buffer
 	pp.AddComment(d.Comment)
-	pp.Add("Module %s.", d.Name)
-	pp.Indent(2)
-	pp.AddLine("Definition S := struct.decl [")
+	pp.Add("Definition %s := struct.decl [", d.Name)
 	pp.Indent(2)
 	for i, fd := range d.Methods {
 		sep := ";"
@@ -172,17 +169,13 @@ func (d InterfaceDecl) CoqDecl() string {
 	}
 	pp.Indent(-2)
 	pp.AddLine("].")
-	pp.Indent(-2)
-	pp.Add("End %s.", d.Name)
 	return pp.Build()
 }
 
 func (d InterfaceDecl) Coq() string {
 	var pp buffer
 	pp.AddComment(d.Comment)
-	pp.Add("Module %s.", d.Name)
-	pp.Indent(2)
-	pp.AddLine("Definition S := struct.decl [")
+	pp.Add("Definition %s := struct.decl [", d.Name)
 	pp.Indent(2)
 	for i, fd := range d.Methods {
 		sep := ";"
@@ -193,8 +186,6 @@ func (d InterfaceDecl) Coq() string {
 	}
 	pp.Indent(-2)
 	pp.AddLine("].")
-	pp.Indent(-2)
-	pp.Add("End %s.", d.Name)
 	return pp.Build()
 }
 
@@ -212,9 +203,9 @@ func (d StructToInterface) Coq() string {
 		pp.Add("rec: \"%s_to_%s\" \"t\" :=", d.Struct, d.Interface)
 		pp.Indent(2)
 		if len(d.Methods) == 1 {
-			pp.Add("struct.mk %s.S [\"%s\" ::= %s__%s \"t\"].", d.Interface, d.Methods[0], d.Struct, d.Methods[0])
+			pp.Add("struct.mk %s [\"%s\" ::= %s__%s \"t\"].", d.Interface, d.Methods[0], d.Struct, d.Methods[0])
 		} else {
-			pp.Add("struct.mk %s.S [", d.Interface)
+			pp.Add("struct.mk %s [", d.Interface)
 			pp.Indent(2)
 			for i, method := range d.Methods {
 				if i == len(d.Methods)-1 {
@@ -1103,7 +1094,7 @@ func StructMethod(structName string, methodName string) string {
 }
 
 func InterfaceMethod(interfaceName string, methodName string) string {
-	return fmt.Sprintf("struct.get %s.S \"%s\"", interfaceName, methodName)
+	return fmt.Sprintf("struct.get %s \"%s\"", interfaceName, methodName)
 }
 
 // TODO: note that the second two lines should be customized depending on the

--- a/internal/coq/coq.go
+++ b/internal/coq/coq.go
@@ -145,7 +145,6 @@ func (d StructDecl) CoqDecl() string {
 	}
 	pp.Indent(-2)
 	pp.AddLine("].")
-	pp.Indent(-2)
 	return pp.Build()
 }
 

--- a/internal/examples/append_log/append_log.gold.v
+++ b/internal/examples/append_log/append_log.gold.v
@@ -10,28 +10,26 @@ From Goose Require github_com.tchajed.marshal.
    appends, which are implemented by atomically updating an on-disk header with
    the number of valid blocks in the log. *)
 
-Module Log.
-  Definition S := struct.decl [
-    "m" :: lockRefT;
-    "sz" :: uint64T;
-    "diskSz" :: uint64T
-  ].
-End Log.
+Definition Log := struct.decl [
+  "m" :: lockRefT;
+  "sz" :: uint64T;
+  "diskSz" :: uint64T
+].
 
 Definition Log__mkHdr: val :=
   rec: "Log__mkHdr" "log" :=
     let: "enc" := marshal.NewEnc disk.BlockSize in
-    marshal.Enc__PutInt "enc" (struct.loadF Log.S "sz" "log");;
-    marshal.Enc__PutInt "enc" (struct.loadF Log.S "diskSz" "log");;
+    marshal.Enc__PutInt "enc" (struct.loadF Log "sz" "log");;
+    marshal.Enc__PutInt "enc" (struct.loadF Log "diskSz" "log");;
     marshal.Enc__Finish "enc".
-Theorem Log__mkHdr_t: ⊢ Log__mkHdr : (struct.ptrT Log.S -> disk.blockT).
+Theorem Log__mkHdr_t: ⊢ Log__mkHdr : (struct.ptrT Log -> disk.blockT).
 Proof. typecheck. Qed.
 Hint Resolve Log__mkHdr_t : types.
 
 Definition Log__writeHdr: val :=
   rec: "Log__writeHdr" "log" :=
     disk.Write #0 (Log__mkHdr "log").
-Theorem Log__writeHdr_t: ⊢ Log__writeHdr : (struct.ptrT Log.S -> unitT).
+Theorem Log__writeHdr_t: ⊢ Log__writeHdr : (struct.ptrT Log -> unitT).
 Proof. typecheck. Qed.
 Hint Resolve Log__writeHdr_t : types.
 
@@ -39,20 +37,20 @@ Definition Init: val :=
   rec: "Init" "diskSz" :=
     (if: "diskSz" < #1
     then
-      (struct.new Log.S [
+      (struct.new Log [
          "m" ::= lock.new #();
          "sz" ::= #0;
          "diskSz" ::= #0
        ], #false)
     else
-      let: "log" := struct.new Log.S [
+      let: "log" := struct.new Log [
         "m" ::= lock.new #();
         "sz" ::= #0;
         "diskSz" ::= "diskSz"
       ] in
       Log__writeHdr "log";;
       ("log", #true)).
-Theorem Init_t: ⊢ Init : (uint64T -> (struct.ptrT Log.S * boolT)).
+Theorem Init_t: ⊢ Init : (uint64T -> (struct.ptrT Log * boolT)).
 Proof. typecheck. Qed.
 Hint Resolve Init_t : types.
 
@@ -62,32 +60,32 @@ Definition Open: val :=
     let: "dec" := marshal.NewDec "hdr" in
     let: "sz" := marshal.Dec__GetInt "dec" in
     let: "diskSz" := marshal.Dec__GetInt "dec" in
-    struct.new Log.S [
+    struct.new Log [
       "m" ::= lock.new #();
       "sz" ::= "sz";
       "diskSz" ::= "diskSz"
     ].
-Theorem Open_t: ⊢ Open : (unitT -> struct.ptrT Log.S).
+Theorem Open_t: ⊢ Open : (unitT -> struct.ptrT Log).
 Proof. typecheck. Qed.
 Hint Resolve Open_t : types.
 
 Definition Log__get: val :=
   rec: "Log__get" "log" "i" :=
-    let: "sz" := struct.loadF Log.S "sz" "log" in
+    let: "sz" := struct.loadF Log "sz" "log" in
     (if: "i" < "sz"
     then (disk.Read (#1 + "i"), #true)
     else (slice.nil, #false)).
-Theorem Log__get_t: ⊢ Log__get : (struct.ptrT Log.S -> uint64T -> (disk.blockT * boolT)).
+Theorem Log__get_t: ⊢ Log__get : (struct.ptrT Log -> uint64T -> (disk.blockT * boolT)).
 Proof. typecheck. Qed.
 Hint Resolve Log__get_t : types.
 
 Definition Log__Get: val :=
   rec: "Log__Get" "log" "i" :=
-    lock.acquire (struct.loadF Log.S "m" "log");;
+    lock.acquire (struct.loadF Log "m" "log");;
     let: ("v", "b") := Log__get "log" "i" in
-    lock.release (struct.loadF Log.S "m" "log");;
+    lock.release (struct.loadF Log "m" "log");;
     ("v", "b").
-Theorem Log__Get_t: ⊢ Log__Get : (struct.ptrT Log.S -> uint64T -> (disk.blockT * boolT)).
+Theorem Log__Get_t: ⊢ Log__Get : (struct.ptrT Log -> uint64T -> (disk.blockT * boolT)).
 Proof. typecheck. Qed.
 Hint Resolve Log__Get_t : types.
 
@@ -101,41 +99,41 @@ Hint Resolve writeAll_t : types.
 
 Definition Log__append: val :=
   rec: "Log__append" "log" "bks" :=
-    let: "sz" := struct.loadF Log.S "sz" "log" in
-    (if: slice.len "bks" ≥ struct.loadF Log.S "diskSz" "log" - #1 - "sz"
+    let: "sz" := struct.loadF Log "sz" "log" in
+    (if: slice.len "bks" ≥ struct.loadF Log "diskSz" "log" - #1 - "sz"
     then #false
     else
       writeAll "bks" (#1 + "sz");;
-      struct.storeF Log.S "sz" "log" (struct.loadF Log.S "sz" "log" + slice.len "bks");;
+      struct.storeF Log "sz" "log" (struct.loadF Log "sz" "log" + slice.len "bks");;
       Log__writeHdr "log";;
       #true).
-Theorem Log__append_t: ⊢ Log__append : (struct.ptrT Log.S -> slice.T disk.blockT -> boolT).
+Theorem Log__append_t: ⊢ Log__append : (struct.ptrT Log -> slice.T disk.blockT -> boolT).
 Proof. typecheck. Qed.
 Hint Resolve Log__append_t : types.
 
 Definition Log__Append: val :=
   rec: "Log__Append" "log" "bks" :=
-    lock.acquire (struct.loadF Log.S "m" "log");;
+    lock.acquire (struct.loadF Log "m" "log");;
     let: "b" := Log__append "log" "bks" in
-    lock.release (struct.loadF Log.S "m" "log");;
+    lock.release (struct.loadF Log "m" "log");;
     "b".
-Theorem Log__Append_t: ⊢ Log__Append : (struct.ptrT Log.S -> slice.T disk.blockT -> boolT).
+Theorem Log__Append_t: ⊢ Log__Append : (struct.ptrT Log -> slice.T disk.blockT -> boolT).
 Proof. typecheck. Qed.
 Hint Resolve Log__Append_t : types.
 
 Definition Log__reset: val :=
   rec: "Log__reset" "log" :=
-    struct.storeF Log.S "sz" "log" #0;;
+    struct.storeF Log "sz" "log" #0;;
     Log__writeHdr "log".
-Theorem Log__reset_t: ⊢ Log__reset : (struct.ptrT Log.S -> unitT).
+Theorem Log__reset_t: ⊢ Log__reset : (struct.ptrT Log -> unitT).
 Proof. typecheck. Qed.
 Hint Resolve Log__reset_t : types.
 
 Definition Log__Reset: val :=
   rec: "Log__Reset" "log" :=
-    lock.acquire (struct.loadF Log.S "m" "log");;
+    lock.acquire (struct.loadF Log "m" "log");;
     Log__reset "log";;
-    lock.release (struct.loadF Log.S "m" "log").
-Theorem Log__Reset_t: ⊢ Log__Reset : (struct.ptrT Log.S -> unitT).
+    lock.release (struct.loadF Log "m" "log").
+Theorem Log__Reset_t: ⊢ Log__Reset : (struct.ptrT Log -> unitT).
 Proof. typecheck. Qed.
 Hint Resolve Log__Reset_t : types.

--- a/internal/examples/comments/comments.gold.v
+++ b/internal/examples/comments/comments.gold.v
@@ -14,8 +14,6 @@ Definition TWO : expr := #2.
 
    it has multiple files *)
 
-Module Foo.
-  Definition S := struct.decl [
-    "a" :: boolT
-  ].
-End Foo.
+Definition Foo := struct.decl [
+  "a" :: boolT
+].

--- a/internal/examples/logging2/logging2.gold.v
+++ b/internal/examples/logging2/logging2.gold.v
@@ -20,30 +20,28 @@ Definition LOGEND : expr := LOGMAXBLK + LOGSTART.
 Theorem LOGEND_t Γ : Γ ⊢ LOGEND : uint64T.
 Proof. typecheck. Qed.
 
-Module Log.
-  Definition S := struct.decl [
-    "logLock" :: lockRefT;
-    "memLock" :: lockRefT;
-    "logSz" :: uint64T;
-    "memLog" :: refT (slice.T disk.blockT);
-    "memLen" :: refT uint64T;
-    "memTxnNxt" :: refT uint64T;
-    "logTxnNxt" :: refT uint64T
-  ].
-End Log.
+Definition Log := struct.decl [
+  "logLock" :: lockRefT;
+  "memLock" :: lockRefT;
+  "logSz" :: uint64T;
+  "memLog" :: refT (slice.T disk.blockT);
+  "memLen" :: refT uint64T;
+  "memTxnNxt" :: refT uint64T;
+  "logTxnNxt" :: refT uint64T
+].
 
 Definition Log__writeHdr: val :=
   rec: "Log__writeHdr" "log" "len" :=
     let: "hdr" := NewSlice byteT #4096 in
     UInt64Put "hdr" "len";;
     disk.Write LOGCOMMIT "hdr".
-Theorem Log__writeHdr_t: ⊢ Log__writeHdr : (struct.t Log.S -> uint64T -> unitT).
+Theorem Log__writeHdr_t: ⊢ Log__writeHdr : (struct.t Log -> uint64T -> unitT).
 Proof. typecheck. Qed.
 Hint Resolve Log__writeHdr_t : types.
 
 Definition Init: val :=
   rec: "Init" "logSz" :=
-    let: "log" := struct.mk Log.S [
+    let: "log" := struct.mk Log [
       "logLock" ::= lock.new #();
       "memLock" ::= lock.new #();
       "logSz" ::= "logSz";
@@ -54,7 +52,7 @@ Definition Init: val :=
     ] in
     Log__writeHdr "log" #0;;
     "log".
-Theorem Init_t: ⊢ Init : (uint64T -> struct.t Log.S).
+Theorem Init_t: ⊢ Init : (uint64T -> struct.t Log).
 Proof. typecheck. Qed.
 Hint Resolve Init_t : types.
 
@@ -63,7 +61,7 @@ Definition Log__readHdr: val :=
     let: "hdr" := disk.Read LOGCOMMIT in
     let: "disklen" := UInt64Get "hdr" in
     "disklen".
-Theorem Log__readHdr_t: ⊢ Log__readHdr : (struct.t Log.S -> uint64T).
+Theorem Log__readHdr_t: ⊢ Log__readHdr : (struct.t Log -> uint64T).
 Proof. typecheck. Qed.
 Hint Resolve Log__readHdr_t : types.
 
@@ -76,18 +74,18 @@ Definition Log__readBlocks: val :=
       "blks" <-[slice.T (slice.T byteT)] SliceAppend (slice.T byteT) (![slice.T (slice.T byteT)] "blks") "blk";;
       Continue);;
     ![slice.T (slice.T byteT)] "blks".
-Theorem Log__readBlocks_t: ⊢ Log__readBlocks : (struct.t Log.S -> uint64T -> slice.T disk.blockT).
+Theorem Log__readBlocks_t: ⊢ Log__readBlocks : (struct.t Log -> uint64T -> slice.T disk.blockT).
 Proof. typecheck. Qed.
 Hint Resolve Log__readBlocks_t : types.
 
 Definition Log__Read: val :=
   rec: "Log__Read" "log" :=
-    lock.acquire (struct.get Log.S "logLock" "log");;
+    lock.acquire (struct.get Log "logLock" "log");;
     let: "disklen" := Log__readHdr "log" in
     let: "blks" := Log__readBlocks "log" "disklen" in
-    lock.release (struct.get Log.S "logLock" "log");;
+    lock.release (struct.get Log "logLock" "log");;
     "blks".
-Theorem Log__Read_t: ⊢ Log__Read : (struct.t Log.S -> slice.T disk.blockT).
+Theorem Log__Read_t: ⊢ Log__Read : (struct.t Log -> slice.T disk.blockT).
 Proof. typecheck. Qed.
 Hint Resolve Log__Read_t : types.
 
@@ -96,38 +94,38 @@ Definition Log__memWrite: val :=
     let: "n" := slice.len "l" in
     let: "i" := ref_to uint64T #0 in
     (for: (λ: <>, ![uint64T] "i" < "n"); (λ: <>, "i" <-[uint64T] ![uint64T] "i" + #1) := λ: <>,
-      struct.get Log.S "memLog" "log" <-[slice.T (slice.T byteT)] SliceAppend (slice.T byteT) (![slice.T (slice.T byteT)] (struct.get Log.S "memLog" "log")) (SliceGet (slice.T byteT) "l" (![uint64T] "i"));;
+      struct.get Log "memLog" "log" <-[slice.T (slice.T byteT)] SliceAppend (slice.T byteT) (![slice.T (slice.T byteT)] (struct.get Log "memLog" "log")) (SliceGet (slice.T byteT) "l" (![uint64T] "i"));;
       Continue).
-Theorem Log__memWrite_t: ⊢ Log__memWrite : (struct.t Log.S -> slice.T disk.blockT -> unitT).
+Theorem Log__memWrite_t: ⊢ Log__memWrite : (struct.t Log -> slice.T disk.blockT -> unitT).
 Proof. typecheck. Qed.
 Hint Resolve Log__memWrite_t : types.
 
 Definition Log__memAppend: val :=
   rec: "Log__memAppend" "log" "l" :=
-    lock.acquire (struct.get Log.S "memLock" "log");;
-    (if: ![uint64T] (struct.get Log.S "memLen" "log") + slice.len "l" ≥ struct.get Log.S "logSz" "log"
+    lock.acquire (struct.get Log "memLock" "log");;
+    (if: ![uint64T] (struct.get Log "memLen" "log") + slice.len "l" ≥ struct.get Log "logSz" "log"
     then
-      lock.release (struct.get Log.S "memLock" "log");;
+      lock.release (struct.get Log "memLock" "log");;
       (#false, #0)
     else
-      let: "txn" := ![uint64T] (struct.get Log.S "memTxnNxt" "log") in
-      let: "n" := ![uint64T] (struct.get Log.S "memLen" "log") + slice.len "l" in
-      struct.get Log.S "memLen" "log" <-[uint64T] "n";;
-      struct.get Log.S "memTxnNxt" "log" <-[uint64T] ![uint64T] (struct.get Log.S "memTxnNxt" "log") + #1;;
-      lock.release (struct.get Log.S "memLock" "log");;
+      let: "txn" := ![uint64T] (struct.get Log "memTxnNxt" "log") in
+      let: "n" := ![uint64T] (struct.get Log "memLen" "log") + slice.len "l" in
+      struct.get Log "memLen" "log" <-[uint64T] "n";;
+      struct.get Log "memTxnNxt" "log" <-[uint64T] ![uint64T] (struct.get Log "memTxnNxt" "log") + #1;;
+      lock.release (struct.get Log "memLock" "log");;
       (#true, "txn")).
-Theorem Log__memAppend_t: ⊢ Log__memAppend : (struct.t Log.S -> slice.T disk.blockT -> (boolT * uint64T)).
+Theorem Log__memAppend_t: ⊢ Log__memAppend : (struct.t Log -> slice.T disk.blockT -> (boolT * uint64T)).
 Proof. typecheck. Qed.
 Hint Resolve Log__memAppend_t : types.
 
 (* XXX just an atomic read? *)
 Definition Log__readLogTxnNxt: val :=
   rec: "Log__readLogTxnNxt" "log" :=
-    lock.acquire (struct.get Log.S "memLock" "log");;
-    let: "n" := ![uint64T] (struct.get Log.S "logTxnNxt" "log") in
-    lock.release (struct.get Log.S "memLock" "log");;
+    lock.acquire (struct.get Log "memLock" "log");;
+    let: "n" := ![uint64T] (struct.get Log "logTxnNxt" "log") in
+    lock.release (struct.get Log "memLock" "log");;
     "n".
-Theorem Log__readLogTxnNxt_t: ⊢ Log__readLogTxnNxt : (struct.t Log.S -> uint64T).
+Theorem Log__readLogTxnNxt_t: ⊢ Log__readLogTxnNxt : (struct.t Log -> uint64T).
 Proof. typecheck. Qed.
 Hint Resolve Log__readLogTxnNxt_t : types.
 
@@ -139,7 +137,7 @@ Definition Log__diskAppendWait: val :=
       (if: "txn" < "logtxn"
       then Break
       else Continue)).
-Theorem Log__diskAppendWait_t: ⊢ Log__diskAppendWait : (struct.t Log.S -> uint64T -> unitT).
+Theorem Log__diskAppendWait_t: ⊢ Log__diskAppendWait : (struct.t Log -> uint64T -> unitT).
 Proof. typecheck. Qed.
 Hint Resolve Log__diskAppendWait_t : types.
 
@@ -152,7 +150,7 @@ Definition Log__Append: val :=
       #()
     else #());;
     "ok".
-Theorem Log__Append_t: ⊢ Log__Append : (struct.t Log.S -> slice.T disk.blockT -> boolT).
+Theorem Log__Append_t: ⊢ Log__Append : (struct.t Log -> slice.T disk.blockT -> boolT).
 Proof. typecheck. Qed.
 Hint Resolve Log__Append_t : types.
 
@@ -164,25 +162,25 @@ Definition Log__writeBlocks: val :=
       let: "bk" := SliceGet (slice.T byteT) "l" (![uint64T] "i") in
       disk.Write ("pos" + ![uint64T] "i") "bk";;
       Continue).
-Theorem Log__writeBlocks_t: ⊢ Log__writeBlocks : (struct.t Log.S -> slice.T disk.blockT -> uint64T -> unitT).
+Theorem Log__writeBlocks_t: ⊢ Log__writeBlocks : (struct.t Log -> slice.T disk.blockT -> uint64T -> unitT).
 Proof. typecheck. Qed.
 Hint Resolve Log__writeBlocks_t : types.
 
 Definition Log__diskAppend: val :=
   rec: "Log__diskAppend" "log" :=
-    lock.acquire (struct.get Log.S "logLock" "log");;
+    lock.acquire (struct.get Log "logLock" "log");;
     let: "disklen" := Log__readHdr "log" in
-    lock.acquire (struct.get Log.S "memLock" "log");;
-    let: "memlen" := ![uint64T] (struct.get Log.S "memLen" "log") in
-    let: "allblks" := ![slice.T (slice.T byteT)] (struct.get Log.S "memLog" "log") in
+    lock.acquire (struct.get Log "memLock" "log");;
+    let: "memlen" := ![uint64T] (struct.get Log "memLen" "log") in
+    let: "allblks" := ![slice.T (slice.T byteT)] (struct.get Log "memLog" "log") in
     let: "blks" := SliceSkip (slice.T byteT) "allblks" "disklen" in
-    let: "memnxt" := ![uint64T] (struct.get Log.S "memTxnNxt" "log") in
-    lock.release (struct.get Log.S "memLock" "log");;
+    let: "memnxt" := ![uint64T] (struct.get Log "memTxnNxt" "log") in
+    lock.release (struct.get Log "memLock" "log");;
     Log__writeBlocks "log" "blks" "disklen";;
     Log__writeHdr "log" "memlen";;
-    struct.get Log.S "logTxnNxt" "log" <-[uint64T] "memnxt";;
-    lock.release (struct.get Log.S "logLock" "log").
-Theorem Log__diskAppend_t: ⊢ Log__diskAppend : (struct.t Log.S -> unitT).
+    struct.get Log "logTxnNxt" "log" <-[uint64T] "memnxt";;
+    lock.release (struct.get Log "logLock" "log").
+Theorem Log__diskAppend_t: ⊢ Log__diskAppend : (struct.t Log -> unitT).
 Proof. typecheck. Qed.
 Hint Resolve Log__diskAppend_t : types.
 
@@ -192,69 +190,67 @@ Definition Log__Logger: val :=
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       Log__diskAppend "log";;
       Continue).
-Theorem Log__Logger_t: ⊢ Log__Logger : (struct.t Log.S -> unitT).
+Theorem Log__Logger_t: ⊢ Log__Logger : (struct.t Log -> unitT).
 Proof. typecheck. Qed.
 Hint Resolve Log__Logger_t : types.
 
 (* txn.go *)
 
-Module Txn.
-  Definition S := struct.decl [
-    "log" :: struct.ptrT Log.S;
-    "blks" :: mapT disk.blockT
-  ].
-End Txn.
+Definition Txn := struct.decl [
+  "log" :: struct.ptrT Log;
+  "blks" :: mapT disk.blockT
+].
 
 (* XXX wait if cannot reserve space in log *)
 Definition Begin: val :=
   rec: "Begin" "log" :=
-    let: "txn" := struct.mk Txn.S [
+    let: "txn" := struct.mk Txn [
       "log" ::= "log";
       "blks" ::= NewMap disk.blockT
     ] in
     "txn".
-Theorem Begin_t: ⊢ Begin : (struct.ptrT Log.S -> struct.t Txn.S).
+Theorem Begin_t: ⊢ Begin : (struct.ptrT Log -> struct.t Txn).
 Proof. typecheck. Qed.
 Hint Resolve Begin_t : types.
 
 Definition Txn__Write: val :=
   rec: "Txn__Write" "txn" "addr" "blk" :=
     let: "ret" := ref_to boolT #true in
-    let: (<>, "ok") := MapGet (struct.get Txn.S "blks" "txn") "addr" in
+    let: (<>, "ok") := MapGet (struct.get Txn "blks" "txn") "addr" in
     (if: "ok"
     then
-      MapInsert (struct.get Txn.S "blks" "txn") "addr" (![slice.T byteT] "blk");;
+      MapInsert (struct.get Txn "blks" "txn") "addr" (![slice.T byteT] "blk");;
       #()
     else #());;
     (if: ~ "ok"
     then
       (if: ("addr" = LOGMAXBLK)
       then "ret" <-[boolT] #false
-      else MapInsert (struct.get Txn.S "blks" "txn") "addr" (![slice.T byteT] "blk"));;
+      else MapInsert (struct.get Txn "blks" "txn") "addr" (![slice.T byteT] "blk"));;
       #()
     else #());;
     ![boolT] "ret".
-Theorem Txn__Write_t: ⊢ Txn__Write : (struct.t Txn.S -> uint64T -> refT disk.blockT -> boolT).
+Theorem Txn__Write_t: ⊢ Txn__Write : (struct.t Txn -> uint64T -> refT disk.blockT -> boolT).
 Proof. typecheck. Qed.
 Hint Resolve Txn__Write_t : types.
 
 Definition Txn__Read: val :=
   rec: "Txn__Read" "txn" "addr" :=
-    let: ("v", "ok") := MapGet (struct.get Txn.S "blks" "txn") "addr" in
+    let: ("v", "ok") := MapGet (struct.get Txn "blks" "txn") "addr" in
     (if: "ok"
     then "v"
     else disk.Read ("addr" + LOGEND)).
-Theorem Txn__Read_t: ⊢ Txn__Read : (struct.t Txn.S -> uint64T -> disk.blockT).
+Theorem Txn__Read_t: ⊢ Txn__Read : (struct.t Txn -> uint64T -> disk.blockT).
 Proof. typecheck. Qed.
 Hint Resolve Txn__Read_t : types.
 
 Definition Txn__Commit: val :=
   rec: "Txn__Commit" "txn" :=
     let: "blks" := ref (zero_val (slice.T disk.blockT)) in
-    MapIter (struct.get Txn.S "blks" "txn") (λ: <> "v",
+    MapIter (struct.get Txn "blks" "txn") (λ: <> "v",
       "blks" <-[slice.T (slice.T byteT)] SliceAppend (slice.T byteT) (![slice.T (slice.T byteT)] "blks") "v");;
-    let: "ok" := Log__Append (struct.load Log.S (struct.get Txn.S "log" "txn")) (![slice.T (slice.T byteT)] "blks") in
+    let: "ok" := Log__Append (struct.load Log (struct.get Txn "log" "txn")) (![slice.T (slice.T byteT)] "blks") in
     "ok".
-Theorem Txn__Commit_t: ⊢ Txn__Commit : (struct.t Txn.S -> boolT).
+Theorem Txn__Commit_t: ⊢ Txn__Commit : (struct.t Txn -> boolT).
 Proof. typecheck. Qed.
 Hint Resolve Txn__Commit_t : types.

--- a/internal/examples/rfc1813/rfc1813.gold.v
+++ b/internal/examples/rfc1813/rfc1813.gold.v
@@ -204,79 +204,61 @@ Definition NF3FIFO : expr := #(U32 7).
 Theorem NF3FIFO_t Γ : Γ ⊢ NF3FIFO : Ftype3.
 Proof. typecheck. Qed.
 
-Module Specdata3.
-  Definition S := struct.decl [
-    "Specdata1" :: Uint32;
-    "Specdata2" :: Uint32
-  ].
-End Specdata3.
+Definition Specdata3 := struct.decl [
+  "Specdata1" :: Uint32;
+  "Specdata2" :: Uint32
+].
 
-Module Nfs_fh3.
-  Definition S := struct.decl [
-    "Data" :: slice.T byteT
-  ].
-End Nfs_fh3.
+Definition Nfs_fh3 := struct.decl [
+  "Data" :: slice.T byteT
+].
 
-Module Nfstime3.
-  Definition S := struct.decl [
-    "Seconds" :: Uint32;
-    "Nseconds" :: Uint32
-  ].
-End Nfstime3.
+Definition Nfstime3 := struct.decl [
+  "Seconds" :: Uint32;
+  "Nseconds" :: Uint32
+].
 
-Module Fattr3.
-  Definition S := struct.decl [
-    "Ftype" :: Ftype3;
-    "Mode" :: Mode3;
-    "Nlink" :: Uint32;
-    "Uid" :: Uid3;
-    "Gid" :: Gid3;
-    "Size" :: Size3;
-    "Used" :: Size3;
-    "Rdev" :: struct.t Specdata3.S;
-    "Fsid" :: Uint64;
-    "Fileid" :: Fileid3;
-    "Atime" :: struct.t Nfstime3.S;
-    "Mtime" :: struct.t Nfstime3.S;
-    "Ctime" :: struct.t Nfstime3.S
-  ].
-End Fattr3.
+Definition Fattr3 := struct.decl [
+  "Ftype" :: Ftype3;
+  "Mode" :: Mode3;
+  "Nlink" :: Uint32;
+  "Uid" :: Uid3;
+  "Gid" :: Gid3;
+  "Size" :: Size3;
+  "Used" :: Size3;
+  "Rdev" :: struct.t Specdata3;
+  "Fsid" :: Uint64;
+  "Fileid" :: Fileid3;
+  "Atime" :: struct.t Nfstime3;
+  "Mtime" :: struct.t Nfstime3;
+  "Ctime" :: struct.t Nfstime3
+].
 
-Module Post_op_attr.
-  Definition S := struct.decl [
-    "Attributes_follow" :: boolT;
-    "Attributes" :: struct.t Fattr3.S
-  ].
-End Post_op_attr.
+Definition Post_op_attr := struct.decl [
+  "Attributes_follow" :: boolT;
+  "Attributes" :: struct.t Fattr3
+].
 
-Module Wcc_attr.
-  Definition S := struct.decl [
-    "Size" :: Size3;
-    "Mtime" :: struct.t Nfstime3.S;
-    "Ctime" :: struct.t Nfstime3.S
-  ].
-End Wcc_attr.
+Definition Wcc_attr := struct.decl [
+  "Size" :: Size3;
+  "Mtime" :: struct.t Nfstime3;
+  "Ctime" :: struct.t Nfstime3
+].
 
-Module Pre_op_attr.
-  Definition S := struct.decl [
-    "Attributes_follow" :: boolT;
-    "Attributes" :: struct.t Wcc_attr.S
-  ].
-End Pre_op_attr.
+Definition Pre_op_attr := struct.decl [
+  "Attributes_follow" :: boolT;
+  "Attributes" :: struct.t Wcc_attr
+].
 
-Module Wcc_data.
-  Definition S := struct.decl [
-    "Before" :: struct.t Pre_op_attr.S;
-    "After" :: struct.t Post_op_attr.S
-  ].
-End Wcc_data.
+Definition Wcc_data := struct.decl [
+  "Before" :: struct.t Pre_op_attr;
+  "After" :: struct.t Post_op_attr
+].
 
-Module Post_op_fh3.
-  Definition S := struct.decl [
-    "Handle_follows" :: boolT;
-    "Handle" :: struct.t Nfs_fh3.S
-  ].
-End Post_op_fh3.
+Definition Post_op_fh3 := struct.decl [
+  "Handle_follows" :: boolT;
+  "Handle" :: struct.t Nfs_fh3
+].
 
 Definition Time_how: ty := uint32T.
 
@@ -292,65 +274,49 @@ Definition SET_TO_CLIENT_TIME : expr := #(U32 2).
 Theorem SET_TO_CLIENT_TIME_t Γ : Γ ⊢ SET_TO_CLIENT_TIME : Time_how.
 Proof. typecheck. Qed.
 
-Module Set_mode3.
-  Definition S := struct.decl [
-    "Set_it" :: boolT;
-    "Mode" :: Mode3
-  ].
-End Set_mode3.
+Definition Set_mode3 := struct.decl [
+  "Set_it" :: boolT;
+  "Mode" :: Mode3
+].
 
-Module Set_uid3.
-  Definition S := struct.decl [
-    "Set_it" :: boolT;
-    "Uid" :: Uid3
-  ].
-End Set_uid3.
+Definition Set_uid3 := struct.decl [
+  "Set_it" :: boolT;
+  "Uid" :: Uid3
+].
 
-Module Set_gid3.
-  Definition S := struct.decl [
-    "Set_it" :: boolT;
-    "Gid" :: Gid3
-  ].
-End Set_gid3.
+Definition Set_gid3 := struct.decl [
+  "Set_it" :: boolT;
+  "Gid" :: Gid3
+].
 
-Module Set_size3.
-  Definition S := struct.decl [
-    "Set_it" :: boolT;
-    "Size" :: Size3
-  ].
-End Set_size3.
+Definition Set_size3 := struct.decl [
+  "Set_it" :: boolT;
+  "Size" :: Size3
+].
 
-Module Set_atime.
-  Definition S := struct.decl [
-    "Set_it" :: Time_how;
-    "Atime" :: struct.t Nfstime3.S
-  ].
-End Set_atime.
+Definition Set_atime := struct.decl [
+  "Set_it" :: Time_how;
+  "Atime" :: struct.t Nfstime3
+].
 
-Module Set_mtime.
-  Definition S := struct.decl [
-    "Set_it" :: Time_how;
-    "Mtime" :: struct.t Nfstime3.S
-  ].
-End Set_mtime.
+Definition Set_mtime := struct.decl [
+  "Set_it" :: Time_how;
+  "Mtime" :: struct.t Nfstime3
+].
 
-Module Sattr3.
-  Definition S := struct.decl [
-    "Mode" :: struct.t Set_mode3.S;
-    "Uid" :: struct.t Set_uid3.S;
-    "Gid" :: struct.t Set_gid3.S;
-    "Size" :: struct.t Set_size3.S;
-    "Atime" :: struct.t Set_atime.S;
-    "Mtime" :: struct.t Set_mtime.S
-  ].
-End Sattr3.
+Definition Sattr3 := struct.decl [
+  "Mode" :: struct.t Set_mode3;
+  "Uid" :: struct.t Set_uid3;
+  "Gid" :: struct.t Set_gid3;
+  "Size" :: struct.t Set_size3;
+  "Atime" :: struct.t Set_atime;
+  "Mtime" :: struct.t Set_mtime
+].
 
-Module Diropargs3.
-  Definition S := struct.decl [
-    "Dir" :: struct.t Nfs_fh3.S;
-    "Name" :: Filename3
-  ].
-End Diropargs3.
+Definition Diropargs3 := struct.decl [
+  "Dir" :: struct.t Nfs_fh3;
+  "Name" :: Filename3
+].
 
 Definition NFS_PROGRAM : expr := #(U32 100003).
 Theorem NFS_PROGRAM_t Γ : Γ ⊢ NFS_PROGRAM : uint32T.
@@ -448,87 +414,63 @@ Definition NFSPROC3_COMMIT : expr := #(U32 21).
 Theorem NFSPROC3_COMMIT_t Γ : Γ ⊢ NFSPROC3_COMMIT : uint32T.
 Proof. typecheck. Qed.
 
-Module GETATTR3args.
-  Definition S := struct.decl [
-    "Object" :: struct.t Nfs_fh3.S
-  ].
-End GETATTR3args.
+Definition GETATTR3args := struct.decl [
+  "Object" :: struct.t Nfs_fh3
+].
 
-Module GETATTR3resok.
-  Definition S := struct.decl [
-    "Obj_attributes" :: struct.t Fattr3.S
-  ].
-End GETATTR3resok.
+Definition GETATTR3resok := struct.decl [
+  "Obj_attributes" :: struct.t Fattr3
+].
 
-Module GETATTR3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t GETATTR3resok.S
-  ].
-End GETATTR3res.
+Definition GETATTR3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t GETATTR3resok
+].
 
-Module Sattrguard3.
-  Definition S := struct.decl [
-    "Check" :: boolT;
-    "Obj_ctime" :: struct.t Nfstime3.S
-  ].
-End Sattrguard3.
+Definition Sattrguard3 := struct.decl [
+  "Check" :: boolT;
+  "Obj_ctime" :: struct.t Nfstime3
+].
 
-Module SETATTR3args.
-  Definition S := struct.decl [
-    "Object" :: struct.t Nfs_fh3.S;
-    "New_attributes" :: struct.t Sattr3.S;
-    "Guard" :: struct.t Sattrguard3.S
-  ].
-End SETATTR3args.
+Definition SETATTR3args := struct.decl [
+  "Object" :: struct.t Nfs_fh3;
+  "New_attributes" :: struct.t Sattr3;
+  "Guard" :: struct.t Sattrguard3
+].
 
-Module SETATTR3resok.
-  Definition S := struct.decl [
-    "Obj_wcc" :: struct.t Wcc_data.S
-  ].
-End SETATTR3resok.
+Definition SETATTR3resok := struct.decl [
+  "Obj_wcc" :: struct.t Wcc_data
+].
 
-Module SETATTR3resfail.
-  Definition S := struct.decl [
-    "Obj_wcc" :: struct.t Wcc_data.S
-  ].
-End SETATTR3resfail.
+Definition SETATTR3resfail := struct.decl [
+  "Obj_wcc" :: struct.t Wcc_data
+].
 
-Module SETATTR3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t SETATTR3resok.S;
-    "Resfail" :: struct.t SETATTR3resfail.S
-  ].
-End SETATTR3res.
+Definition SETATTR3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t SETATTR3resok;
+  "Resfail" :: struct.t SETATTR3resfail
+].
 
-Module LOOKUP3args.
-  Definition S := struct.decl [
-    "What" :: struct.t Diropargs3.S
-  ].
-End LOOKUP3args.
+Definition LOOKUP3args := struct.decl [
+  "What" :: struct.t Diropargs3
+].
 
-Module LOOKUP3resok.
-  Definition S := struct.decl [
-    "Object" :: struct.t Nfs_fh3.S;
-    "Obj_attributes" :: struct.t Post_op_attr.S;
-    "Dir_attributes" :: struct.t Post_op_attr.S
-  ].
-End LOOKUP3resok.
+Definition LOOKUP3resok := struct.decl [
+  "Object" :: struct.t Nfs_fh3;
+  "Obj_attributes" :: struct.t Post_op_attr;
+  "Dir_attributes" :: struct.t Post_op_attr
+].
 
-Module LOOKUP3resfail.
-  Definition S := struct.decl [
-    "Dir_attributes" :: struct.t Post_op_attr.S
-  ].
-End LOOKUP3resfail.
+Definition LOOKUP3resfail := struct.decl [
+  "Dir_attributes" :: struct.t Post_op_attr
+].
 
-Module LOOKUP3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t LOOKUP3resok.S;
-    "Resfail" :: struct.t LOOKUP3resfail.S
-  ].
-End LOOKUP3res.
+Definition LOOKUP3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t LOOKUP3resok;
+  "Resfail" :: struct.t LOOKUP3resfail
+].
 
 Definition ACCESS3_READ : expr := #(U32 1).
 Theorem ACCESS3_READ_t Γ : Γ ⊢ ACCESS3_READ : uint32T.
@@ -554,91 +496,67 @@ Definition ACCESS3_EXECUTE : expr := #(U32 32).
 Theorem ACCESS3_EXECUTE_t Γ : Γ ⊢ ACCESS3_EXECUTE : uint32T.
 Proof. typecheck. Qed.
 
-Module ACCESS3args.
-  Definition S := struct.decl [
-    "Object" :: struct.t Nfs_fh3.S;
-    "Access" :: Uint32
-  ].
-End ACCESS3args.
+Definition ACCESS3args := struct.decl [
+  "Object" :: struct.t Nfs_fh3;
+  "Access" :: Uint32
+].
 
-Module ACCESS3resok.
-  Definition S := struct.decl [
-    "Obj_attributes" :: struct.t Post_op_attr.S;
-    "Access" :: Uint32
-  ].
-End ACCESS3resok.
+Definition ACCESS3resok := struct.decl [
+  "Obj_attributes" :: struct.t Post_op_attr;
+  "Access" :: Uint32
+].
 
-Module ACCESS3resfail.
-  Definition S := struct.decl [
-    "Obj_attributes" :: struct.t Post_op_attr.S
-  ].
-End ACCESS3resfail.
+Definition ACCESS3resfail := struct.decl [
+  "Obj_attributes" :: struct.t Post_op_attr
+].
 
-Module ACCESS3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t ACCESS3resok.S;
-    "Resfail" :: struct.t ACCESS3resfail.S
-  ].
-End ACCESS3res.
+Definition ACCESS3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t ACCESS3resok;
+  "Resfail" :: struct.t ACCESS3resfail
+].
 
-Module READLINK3args.
-  Definition S := struct.decl [
-    "Symlink" :: struct.t Nfs_fh3.S
-  ].
-End READLINK3args.
+Definition READLINK3args := struct.decl [
+  "Symlink" :: struct.t Nfs_fh3
+].
 
-Module READLINK3resok.
-  Definition S := struct.decl [
-    "Symlink_attributes" :: struct.t Post_op_attr.S;
-    "Data" :: Nfspath3
-  ].
-End READLINK3resok.
+Definition READLINK3resok := struct.decl [
+  "Symlink_attributes" :: struct.t Post_op_attr;
+  "Data" :: Nfspath3
+].
 
-Module READLINK3resfail.
-  Definition S := struct.decl [
-    "Symlink_attributes" :: struct.t Post_op_attr.S
-  ].
-End READLINK3resfail.
+Definition READLINK3resfail := struct.decl [
+  "Symlink_attributes" :: struct.t Post_op_attr
+].
 
-Module READLINK3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t READLINK3resok.S;
-    "Resfail" :: struct.t READLINK3resfail.S
-  ].
-End READLINK3res.
+Definition READLINK3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t READLINK3resok;
+  "Resfail" :: struct.t READLINK3resfail
+].
 
-Module READ3args.
-  Definition S := struct.decl [
-    "File" :: struct.t Nfs_fh3.S;
-    "Offset" :: Offset3;
-    "Count" :: Count3
-  ].
-End READ3args.
+Definition READ3args := struct.decl [
+  "File" :: struct.t Nfs_fh3;
+  "Offset" :: Offset3;
+  "Count" :: Count3
+].
 
-Module READ3resok.
-  Definition S := struct.decl [
-    "File_attributes" :: struct.t Post_op_attr.S;
-    "Count" :: Count3;
-    "Eof" :: boolT;
-    "Data" :: slice.T byteT
-  ].
-End READ3resok.
+Definition READ3resok := struct.decl [
+  "File_attributes" :: struct.t Post_op_attr;
+  "Count" :: Count3;
+  "Eof" :: boolT;
+  "Data" :: slice.T byteT
+].
 
-Module READ3resfail.
-  Definition S := struct.decl [
-    "File_attributes" :: struct.t Post_op_attr.S
-  ].
-End READ3resfail.
+Definition READ3resfail := struct.decl [
+  "File_attributes" :: struct.t Post_op_attr
+].
 
-Module READ3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t READ3resok.S;
-    "Resfail" :: struct.t READ3resfail.S
-  ].
-End READ3res.
+Definition READ3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t READ3resok;
+  "Resfail" :: struct.t READ3resfail
+].
 
 Definition Stable_how: ty := uint32T.
 
@@ -654,38 +572,30 @@ Definition FILE_SYNC : expr := #(U32 2).
 Theorem FILE_SYNC_t Γ : Γ ⊢ FILE_SYNC : Stable_how.
 Proof. typecheck. Qed.
 
-Module WRITE3args.
-  Definition S := struct.decl [
-    "File" :: struct.t Nfs_fh3.S;
-    "Offset" :: Offset3;
-    "Count" :: Count3;
-    "Stable" :: Stable_how;
-    "Data" :: slice.T byteT
-  ].
-End WRITE3args.
+Definition WRITE3args := struct.decl [
+  "File" :: struct.t Nfs_fh3;
+  "Offset" :: Offset3;
+  "Count" :: Count3;
+  "Stable" :: Stable_how;
+  "Data" :: slice.T byteT
+].
 
-Module WRITE3resok.
-  Definition S := struct.decl [
-    "File_wcc" :: struct.t Wcc_data.S;
-    "Count" :: Count3;
-    "Committed" :: Stable_how;
-    "Verf" :: Writeverf3
-  ].
-End WRITE3resok.
+Definition WRITE3resok := struct.decl [
+  "File_wcc" :: struct.t Wcc_data;
+  "Count" :: Count3;
+  "Committed" :: Stable_how;
+  "Verf" :: Writeverf3
+].
 
-Module WRITE3resfail.
-  Definition S := struct.decl [
-    "File_wcc" :: struct.t Wcc_data.S
-  ].
-End WRITE3resfail.
+Definition WRITE3resfail := struct.decl [
+  "File_wcc" :: struct.t Wcc_data
+].
 
-Module WRITE3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t WRITE3resok.S;
-    "Resfail" :: struct.t WRITE3resfail.S
-  ].
-End WRITE3res.
+Definition WRITE3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t WRITE3resok;
+  "Resfail" :: struct.t WRITE3resfail
+].
 
 Definition Createmode3: ty := uint32T.
 
@@ -701,391 +611,287 @@ Definition EXCLUSIVE : expr := #(U32 2).
 Theorem EXCLUSIVE_t Γ : Γ ⊢ EXCLUSIVE : Createmode3.
 Proof. typecheck. Qed.
 
-Module Createhow3.
-  Definition S := struct.decl [
-    "Mode" :: Createmode3;
-    "Obj_attributes" :: struct.t Sattr3.S;
-    "Verf" :: Createverf3
-  ].
-End Createhow3.
+Definition Createhow3 := struct.decl [
+  "Mode" :: Createmode3;
+  "Obj_attributes" :: struct.t Sattr3;
+  "Verf" :: Createverf3
+].
 
-Module CREATE3args.
-  Definition S := struct.decl [
-    "Where" :: struct.t Diropargs3.S;
-    "How" :: struct.t Createhow3.S
-  ].
-End CREATE3args.
+Definition CREATE3args := struct.decl [
+  "Where" :: struct.t Diropargs3;
+  "How" :: struct.t Createhow3
+].
 
-Module CREATE3resok.
-  Definition S := struct.decl [
-    "Obj" :: struct.t Post_op_fh3.S;
-    "Obj_attributes" :: struct.t Post_op_attr.S;
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End CREATE3resok.
+Definition CREATE3resok := struct.decl [
+  "Obj" :: struct.t Post_op_fh3;
+  "Obj_attributes" :: struct.t Post_op_attr;
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module CREATE3resfail.
-  Definition S := struct.decl [
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End CREATE3resfail.
+Definition CREATE3resfail := struct.decl [
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module CREATE3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t CREATE3resok.S;
-    "Resfail" :: struct.t CREATE3resfail.S
-  ].
-End CREATE3res.
+Definition CREATE3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t CREATE3resok;
+  "Resfail" :: struct.t CREATE3resfail
+].
 
-Module MKDIR3args.
-  Definition S := struct.decl [
-    "Where" :: struct.t Diropargs3.S;
-    "Attributes" :: struct.t Sattr3.S
-  ].
-End MKDIR3args.
+Definition MKDIR3args := struct.decl [
+  "Where" :: struct.t Diropargs3;
+  "Attributes" :: struct.t Sattr3
+].
 
-Module MKDIR3resok.
-  Definition S := struct.decl [
-    "Obj" :: struct.t Post_op_fh3.S;
-    "Obj_attributes" :: struct.t Post_op_attr.S;
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End MKDIR3resok.
+Definition MKDIR3resok := struct.decl [
+  "Obj" :: struct.t Post_op_fh3;
+  "Obj_attributes" :: struct.t Post_op_attr;
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module MKDIR3resfail.
-  Definition S := struct.decl [
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End MKDIR3resfail.
+Definition MKDIR3resfail := struct.decl [
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module MKDIR3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t MKDIR3resok.S;
-    "Resfail" :: struct.t MKDIR3resfail.S
-  ].
-End MKDIR3res.
+Definition MKDIR3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t MKDIR3resok;
+  "Resfail" :: struct.t MKDIR3resfail
+].
 
-Module Symlinkdata3.
-  Definition S := struct.decl [
-    "Symlink_attributes" :: struct.t Sattr3.S;
-    "Symlink_data" :: Nfspath3
-  ].
-End Symlinkdata3.
+Definition Symlinkdata3 := struct.decl [
+  "Symlink_attributes" :: struct.t Sattr3;
+  "Symlink_data" :: Nfspath3
+].
 
-Module SYMLINK3args.
-  Definition S := struct.decl [
-    "Where" :: struct.t Diropargs3.S;
-    "Symlink" :: struct.t Symlinkdata3.S
-  ].
-End SYMLINK3args.
+Definition SYMLINK3args := struct.decl [
+  "Where" :: struct.t Diropargs3;
+  "Symlink" :: struct.t Symlinkdata3
+].
 
-Module SYMLINK3resok.
-  Definition S := struct.decl [
-    "Obj" :: struct.t Post_op_fh3.S;
-    "Obj_attributes" :: struct.t Post_op_attr.S;
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End SYMLINK3resok.
+Definition SYMLINK3resok := struct.decl [
+  "Obj" :: struct.t Post_op_fh3;
+  "Obj_attributes" :: struct.t Post_op_attr;
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module SYMLINK3resfail.
-  Definition S := struct.decl [
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End SYMLINK3resfail.
+Definition SYMLINK3resfail := struct.decl [
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module SYMLINK3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t SYMLINK3resok.S;
-    "Resfail" :: struct.t SYMLINK3resfail.S
-  ].
-End SYMLINK3res.
+Definition SYMLINK3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t SYMLINK3resok;
+  "Resfail" :: struct.t SYMLINK3resfail
+].
 
-Module Devicedata3.
-  Definition S := struct.decl [
-    "Dev_attributes" :: struct.t Sattr3.S;
-    "Spec" :: struct.t Specdata3.S
-  ].
-End Devicedata3.
+Definition Devicedata3 := struct.decl [
+  "Dev_attributes" :: struct.t Sattr3;
+  "Spec" :: struct.t Specdata3
+].
 
-Module Mknoddata3.
-  Definition S := struct.decl [
-    "Ftype" :: Ftype3;
-    "Device" :: struct.t Devicedata3.S;
-    "Pipe_attributes" :: struct.t Sattr3.S
-  ].
-End Mknoddata3.
+Definition Mknoddata3 := struct.decl [
+  "Ftype" :: Ftype3;
+  "Device" :: struct.t Devicedata3;
+  "Pipe_attributes" :: struct.t Sattr3
+].
 
-Module MKNOD3args.
-  Definition S := struct.decl [
-    "Where" :: struct.t Diropargs3.S;
-    "What" :: struct.t Mknoddata3.S
-  ].
-End MKNOD3args.
+Definition MKNOD3args := struct.decl [
+  "Where" :: struct.t Diropargs3;
+  "What" :: struct.t Mknoddata3
+].
 
-Module MKNOD3resok.
-  Definition S := struct.decl [
-    "Obj" :: struct.t Post_op_fh3.S;
-    "Obj_attributes" :: struct.t Post_op_attr.S;
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End MKNOD3resok.
+Definition MKNOD3resok := struct.decl [
+  "Obj" :: struct.t Post_op_fh3;
+  "Obj_attributes" :: struct.t Post_op_attr;
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module MKNOD3resfail.
-  Definition S := struct.decl [
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End MKNOD3resfail.
+Definition MKNOD3resfail := struct.decl [
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module MKNOD3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t MKNOD3resok.S;
-    "Resfail" :: struct.t MKNOD3resfail.S
-  ].
-End MKNOD3res.
+Definition MKNOD3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t MKNOD3resok;
+  "Resfail" :: struct.t MKNOD3resfail
+].
 
-Module REMOVE3args.
-  Definition S := struct.decl [
-    "Object" :: struct.t Diropargs3.S
-  ].
-End REMOVE3args.
+Definition REMOVE3args := struct.decl [
+  "Object" :: struct.t Diropargs3
+].
 
-Module REMOVE3resok.
-  Definition S := struct.decl [
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End REMOVE3resok.
+Definition REMOVE3resok := struct.decl [
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module REMOVE3resfail.
-  Definition S := struct.decl [
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End REMOVE3resfail.
+Definition REMOVE3resfail := struct.decl [
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module REMOVE3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t REMOVE3resok.S;
-    "Resfail" :: struct.t REMOVE3resfail.S
-  ].
-End REMOVE3res.
+Definition REMOVE3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t REMOVE3resok;
+  "Resfail" :: struct.t REMOVE3resfail
+].
 
-Module RMDIR3args.
-  Definition S := struct.decl [
-    "Object" :: struct.t Diropargs3.S
-  ].
-End RMDIR3args.
+Definition RMDIR3args := struct.decl [
+  "Object" :: struct.t Diropargs3
+].
 
-Module RMDIR3resok.
-  Definition S := struct.decl [
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End RMDIR3resok.
+Definition RMDIR3resok := struct.decl [
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module RMDIR3resfail.
-  Definition S := struct.decl [
-    "Dir_wcc" :: struct.t Wcc_data.S
-  ].
-End RMDIR3resfail.
+Definition RMDIR3resfail := struct.decl [
+  "Dir_wcc" :: struct.t Wcc_data
+].
 
-Module RMDIR3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t RMDIR3resok.S;
-    "Resfail" :: struct.t RMDIR3resfail.S
-  ].
-End RMDIR3res.
+Definition RMDIR3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t RMDIR3resok;
+  "Resfail" :: struct.t RMDIR3resfail
+].
 
-Module RENAME3args.
-  Definition S := struct.decl [
-    "From" :: struct.t Diropargs3.S;
-    "To" :: struct.t Diropargs3.S
-  ].
-End RENAME3args.
+Definition RENAME3args := struct.decl [
+  "From" :: struct.t Diropargs3;
+  "To" :: struct.t Diropargs3
+].
 
-Module RENAME3resok.
-  Definition S := struct.decl [
-    "Fromdir_wcc" :: struct.t Wcc_data.S;
-    "Todir_wcc" :: struct.t Wcc_data.S
-  ].
-End RENAME3resok.
+Definition RENAME3resok := struct.decl [
+  "Fromdir_wcc" :: struct.t Wcc_data;
+  "Todir_wcc" :: struct.t Wcc_data
+].
 
-Module RENAME3resfail.
-  Definition S := struct.decl [
-    "Fromdir_wcc" :: struct.t Wcc_data.S;
-    "Todir_wcc" :: struct.t Wcc_data.S
-  ].
-End RENAME3resfail.
+Definition RENAME3resfail := struct.decl [
+  "Fromdir_wcc" :: struct.t Wcc_data;
+  "Todir_wcc" :: struct.t Wcc_data
+].
 
-Module RENAME3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t RENAME3resok.S;
-    "Resfail" :: struct.t RENAME3resfail.S
-  ].
-End RENAME3res.
+Definition RENAME3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t RENAME3resok;
+  "Resfail" :: struct.t RENAME3resfail
+].
 
-Module LINK3args.
-  Definition S := struct.decl [
-    "File" :: struct.t Nfs_fh3.S;
-    "Link" :: struct.t Diropargs3.S
-  ].
-End LINK3args.
+Definition LINK3args := struct.decl [
+  "File" :: struct.t Nfs_fh3;
+  "Link" :: struct.t Diropargs3
+].
 
-Module LINK3resok.
-  Definition S := struct.decl [
-    "File_attributes" :: struct.t Post_op_attr.S;
-    "Linkdir_wcc" :: struct.t Wcc_data.S
-  ].
-End LINK3resok.
+Definition LINK3resok := struct.decl [
+  "File_attributes" :: struct.t Post_op_attr;
+  "Linkdir_wcc" :: struct.t Wcc_data
+].
 
-Module LINK3resfail.
-  Definition S := struct.decl [
-    "File_attributes" :: struct.t Post_op_attr.S;
-    "Linkdir_wcc" :: struct.t Wcc_data.S
-  ].
-End LINK3resfail.
+Definition LINK3resfail := struct.decl [
+  "File_attributes" :: struct.t Post_op_attr;
+  "Linkdir_wcc" :: struct.t Wcc_data
+].
 
-Module LINK3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t LINK3resok.S;
-    "Resfail" :: struct.t LINK3resfail.S
-  ].
-End LINK3res.
+Definition LINK3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t LINK3resok;
+  "Resfail" :: struct.t LINK3resfail
+].
 
-Module READDIR3args.
-  Definition S := struct.decl [
-    "Dir" :: struct.t Nfs_fh3.S;
-    "Cookie" :: Cookie3;
-    "Cookieverf" :: Cookieverf3;
-    "Count" :: Count3
-  ].
-End READDIR3args.
+Definition READDIR3args := struct.decl [
+  "Dir" :: struct.t Nfs_fh3;
+  "Cookie" :: Cookie3;
+  "Cookieverf" :: Cookieverf3;
+  "Count" :: Count3
+].
 
-Module Entry3.
-  Definition S := struct.decl [
-    "Fileid" :: Fileid3;
-    "Name" :: Filename3;
-    "Cookie" :: Cookie3;
-    "Nextentry" :: refT anyT
-  ].
-End Entry3.
+Definition Entry3 := struct.decl [
+  "Fileid" :: Fileid3;
+  "Name" :: Filename3;
+  "Cookie" :: Cookie3;
+  "Nextentry" :: refT anyT
+].
 
-Module Dirlist3.
-  Definition S := struct.decl [
-    "Entries" :: struct.ptrT Entry3.S;
-    "Eof" :: boolT
-  ].
-End Dirlist3.
+Definition Dirlist3 := struct.decl [
+  "Entries" :: struct.ptrT Entry3;
+  "Eof" :: boolT
+].
 
-Module READDIR3resok.
-  Definition S := struct.decl [
-    "Dir_attributes" :: struct.t Post_op_attr.S;
-    "Cookieverf" :: Cookieverf3;
-    "Reply" :: struct.t Dirlist3.S
-  ].
-End READDIR3resok.
+Definition READDIR3resok := struct.decl [
+  "Dir_attributes" :: struct.t Post_op_attr;
+  "Cookieverf" :: Cookieverf3;
+  "Reply" :: struct.t Dirlist3
+].
 
-Module READDIR3resfail.
-  Definition S := struct.decl [
-    "Dir_attributes" :: struct.t Post_op_attr.S
-  ].
-End READDIR3resfail.
+Definition READDIR3resfail := struct.decl [
+  "Dir_attributes" :: struct.t Post_op_attr
+].
 
-Module READDIR3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t READDIR3resok.S;
-    "Resfail" :: struct.t READDIR3resfail.S
-  ].
-End READDIR3res.
+Definition READDIR3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t READDIR3resok;
+  "Resfail" :: struct.t READDIR3resfail
+].
 
-Module READDIRPLUS3args.
-  Definition S := struct.decl [
-    "Dir" :: struct.t Nfs_fh3.S;
-    "Cookie" :: Cookie3;
-    "Cookieverf" :: Cookieverf3;
-    "Dircount" :: Count3;
-    "Maxcount" :: Count3
-  ].
-End READDIRPLUS3args.
+Definition READDIRPLUS3args := struct.decl [
+  "Dir" :: struct.t Nfs_fh3;
+  "Cookie" :: Cookie3;
+  "Cookieverf" :: Cookieverf3;
+  "Dircount" :: Count3;
+  "Maxcount" :: Count3
+].
 
-Module Entryplus3.
-  Definition S := struct.decl [
-    "Fileid" :: Fileid3;
-    "Name" :: Filename3;
-    "Cookie" :: Cookie3;
-    "Name_attributes" :: struct.t Post_op_attr.S;
-    "Name_handle" :: struct.t Post_op_fh3.S;
-    "Nextentry" :: refT anyT
-  ].
-End Entryplus3.
+Definition Entryplus3 := struct.decl [
+  "Fileid" :: Fileid3;
+  "Name" :: Filename3;
+  "Cookie" :: Cookie3;
+  "Name_attributes" :: struct.t Post_op_attr;
+  "Name_handle" :: struct.t Post_op_fh3;
+  "Nextentry" :: refT anyT
+].
 
-Module Dirlistplus3.
-  Definition S := struct.decl [
-    "Entries" :: struct.ptrT Entryplus3.S;
-    "Eof" :: boolT
-  ].
-End Dirlistplus3.
+Definition Dirlistplus3 := struct.decl [
+  "Entries" :: struct.ptrT Entryplus3;
+  "Eof" :: boolT
+].
 
-Module READDIRPLUS3resok.
-  Definition S := struct.decl [
-    "Dir_attributes" :: struct.t Post_op_attr.S;
-    "Cookieverf" :: Cookieverf3;
-    "Reply" :: struct.t Dirlistplus3.S
-  ].
-End READDIRPLUS3resok.
+Definition READDIRPLUS3resok := struct.decl [
+  "Dir_attributes" :: struct.t Post_op_attr;
+  "Cookieverf" :: Cookieverf3;
+  "Reply" :: struct.t Dirlistplus3
+].
 
-Module READDIRPLUS3resfail.
-  Definition S := struct.decl [
-    "Dir_attributes" :: struct.t Post_op_attr.S
-  ].
-End READDIRPLUS3resfail.
+Definition READDIRPLUS3resfail := struct.decl [
+  "Dir_attributes" :: struct.t Post_op_attr
+].
 
-Module READDIRPLUS3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t READDIRPLUS3resok.S;
-    "Resfail" :: struct.t READDIRPLUS3resfail.S
-  ].
-End READDIRPLUS3res.
+Definition READDIRPLUS3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t READDIRPLUS3resok;
+  "Resfail" :: struct.t READDIRPLUS3resfail
+].
 
-Module FSSTAT3args.
-  Definition S := struct.decl [
-    "Fsroot" :: struct.t Nfs_fh3.S
-  ].
-End FSSTAT3args.
+Definition FSSTAT3args := struct.decl [
+  "Fsroot" :: struct.t Nfs_fh3
+].
 
-Module FSSTAT3resok.
-  Definition S := struct.decl [
-    "Obj_attributes" :: struct.t Post_op_attr.S;
-    "Tbytes" :: Size3;
-    "Fbytes" :: Size3;
-    "Abytes" :: Size3;
-    "Tfiles" :: Size3;
-    "Ffiles" :: Size3;
-    "Afiles" :: Size3;
-    "Invarsec" :: Uint32
-  ].
-End FSSTAT3resok.
+Definition FSSTAT3resok := struct.decl [
+  "Obj_attributes" :: struct.t Post_op_attr;
+  "Tbytes" :: Size3;
+  "Fbytes" :: Size3;
+  "Abytes" :: Size3;
+  "Tfiles" :: Size3;
+  "Ffiles" :: Size3;
+  "Afiles" :: Size3;
+  "Invarsec" :: Uint32
+].
 
-Module FSSTAT3resfail.
-  Definition S := struct.decl [
-    "Obj_attributes" :: struct.t Post_op_attr.S
-  ].
-End FSSTAT3resfail.
+Definition FSSTAT3resfail := struct.decl [
+  "Obj_attributes" :: struct.t Post_op_attr
+].
 
-Module FSSTAT3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t FSSTAT3resok.S;
-    "Resfail" :: struct.t FSSTAT3resfail.S
-  ].
-End FSSTAT3res.
+Definition FSSTAT3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t FSSTAT3resok;
+  "Resfail" :: struct.t FSSTAT3resfail
+].
 
 Definition FSF3_LINK : expr := #(U32 1).
 Theorem FSF3_LINK_t Γ : Γ ⊢ FSF3_LINK : uint32T.
@@ -1103,102 +909,78 @@ Definition FSF3_CANSETTIME : expr := #(U32 16).
 Theorem FSF3_CANSETTIME_t Γ : Γ ⊢ FSF3_CANSETTIME : uint32T.
 Proof. typecheck. Qed.
 
-Module FSINFO3args.
-  Definition S := struct.decl [
-    "Fsroot" :: struct.t Nfs_fh3.S
-  ].
-End FSINFO3args.
+Definition FSINFO3args := struct.decl [
+  "Fsroot" :: struct.t Nfs_fh3
+].
 
-Module FSINFO3resok.
-  Definition S := struct.decl [
-    "Obj_attributes" :: struct.t Post_op_attr.S;
-    "Rtmax" :: Uint32;
-    "Rtpref" :: Uint32;
-    "Rtmult" :: Uint32;
-    "Wtmax" :: Uint32;
-    "Wtpref" :: Uint32;
-    "Wtmult" :: Uint32;
-    "Dtpref" :: Uint32;
-    "Maxfilesize" :: Size3;
-    "Time_delta" :: struct.t Nfstime3.S;
-    "Properties" :: Uint32
-  ].
-End FSINFO3resok.
+Definition FSINFO3resok := struct.decl [
+  "Obj_attributes" :: struct.t Post_op_attr;
+  "Rtmax" :: Uint32;
+  "Rtpref" :: Uint32;
+  "Rtmult" :: Uint32;
+  "Wtmax" :: Uint32;
+  "Wtpref" :: Uint32;
+  "Wtmult" :: Uint32;
+  "Dtpref" :: Uint32;
+  "Maxfilesize" :: Size3;
+  "Time_delta" :: struct.t Nfstime3;
+  "Properties" :: Uint32
+].
 
-Module FSINFO3resfail.
-  Definition S := struct.decl [
-    "Obj_attributes" :: struct.t Post_op_attr.S
-  ].
-End FSINFO3resfail.
+Definition FSINFO3resfail := struct.decl [
+  "Obj_attributes" :: struct.t Post_op_attr
+].
 
-Module FSINFO3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t FSINFO3resok.S;
-    "Resfail" :: struct.t FSINFO3resfail.S
-  ].
-End FSINFO3res.
+Definition FSINFO3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t FSINFO3resok;
+  "Resfail" :: struct.t FSINFO3resfail
+].
 
-Module PATHCONF3args.
-  Definition S := struct.decl [
-    "Object" :: struct.t Nfs_fh3.S
-  ].
-End PATHCONF3args.
+Definition PATHCONF3args := struct.decl [
+  "Object" :: struct.t Nfs_fh3
+].
 
-Module PATHCONF3resok.
-  Definition S := struct.decl [
-    "Obj_attributes" :: struct.t Post_op_attr.S;
-    "Linkmax" :: Uint32;
-    "Name_max" :: Uint32;
-    "No_trunc" :: boolT;
-    "Chown_restricted" :: boolT;
-    "Case_insensitive" :: boolT;
-    "Case_preserving" :: boolT
-  ].
-End PATHCONF3resok.
+Definition PATHCONF3resok := struct.decl [
+  "Obj_attributes" :: struct.t Post_op_attr;
+  "Linkmax" :: Uint32;
+  "Name_max" :: Uint32;
+  "No_trunc" :: boolT;
+  "Chown_restricted" :: boolT;
+  "Case_insensitive" :: boolT;
+  "Case_preserving" :: boolT
+].
 
-Module PATHCONF3resfail.
-  Definition S := struct.decl [
-    "Obj_attributes" :: struct.t Post_op_attr.S
-  ].
-End PATHCONF3resfail.
+Definition PATHCONF3resfail := struct.decl [
+  "Obj_attributes" :: struct.t Post_op_attr
+].
 
-Module PATHCONF3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t PATHCONF3resok.S;
-    "Resfail" :: struct.t PATHCONF3resfail.S
-  ].
-End PATHCONF3res.
+Definition PATHCONF3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t PATHCONF3resok;
+  "Resfail" :: struct.t PATHCONF3resfail
+].
 
-Module COMMIT3args.
-  Definition S := struct.decl [
-    "File" :: struct.t Nfs_fh3.S;
-    "Offset" :: Offset3;
-    "Count" :: Count3
-  ].
-End COMMIT3args.
+Definition COMMIT3args := struct.decl [
+  "File" :: struct.t Nfs_fh3;
+  "Offset" :: Offset3;
+  "Count" :: Count3
+].
 
-Module COMMIT3resok.
-  Definition S := struct.decl [
-    "File_wcc" :: struct.t Wcc_data.S;
-    "Verf" :: Writeverf3
-  ].
-End COMMIT3resok.
+Definition COMMIT3resok := struct.decl [
+  "File_wcc" :: struct.t Wcc_data;
+  "Verf" :: Writeverf3
+].
 
-Module COMMIT3resfail.
-  Definition S := struct.decl [
-    "File_wcc" :: struct.t Wcc_data.S
-  ].
-End COMMIT3resfail.
+Definition COMMIT3resfail := struct.decl [
+  "File_wcc" :: struct.t Wcc_data
+].
 
-Module COMMIT3res.
-  Definition S := struct.decl [
-    "Status" :: Nfsstat3;
-    "Resok" :: struct.t COMMIT3resok.S;
-    "Resfail" :: struct.t COMMIT3resfail.S
-  ].
-End COMMIT3res.
+Definition COMMIT3res := struct.decl [
+  "Status" :: Nfsstat3;
+  "Resok" :: struct.t COMMIT3resok;
+  "Resfail" :: struct.t COMMIT3resfail
+].
 
 Definition MNTPATHLEN3 : expr := #(U32 1024).
 Theorem MNTPATHLEN3_t Γ : Γ ⊢ MNTPATHLEN3 : uint32T.
@@ -1292,51 +1074,37 @@ Definition MOUNTPROC3_EXPORT : expr := #(U32 5).
 Theorem MOUNTPROC3_EXPORT_t Γ : Γ ⊢ MOUNTPROC3_EXPORT : uint32T.
 Proof. typecheck. Qed.
 
-Module Mountres3_ok.
-  Definition S := struct.decl [
-    "Fhandle" :: Fhandle3;
-    "Auth_flavors" :: slice.T uint32T
-  ].
-End Mountres3_ok.
+Definition Mountres3_ok := struct.decl [
+  "Fhandle" :: Fhandle3;
+  "Auth_flavors" :: slice.T uint32T
+].
 
-Module Mountres3.
-  Definition S := struct.decl [
-    "Fhs_status" :: Mountstat3;
-    "Mountinfo" :: struct.t Mountres3_ok.S
-  ].
-End Mountres3.
+Definition Mountres3 := struct.decl [
+  "Fhs_status" :: Mountstat3;
+  "Mountinfo" :: struct.t Mountres3_ok
+].
 
-Module Mount3.
-  Definition S := struct.decl [
-    "Ml_hostname" :: Name3;
-    "Ml_directory" :: Dirpath3;
-    "Ml_next" :: refT anyT
-  ].
-End Mount3.
+Definition Mount3 := struct.decl [
+  "Ml_hostname" :: Name3;
+  "Ml_directory" :: Dirpath3;
+  "Ml_next" :: refT anyT
+].
 
-Module Mountopt3.
-  Definition S := struct.decl [
-    "P" :: struct.ptrT Mount3.S
-  ].
-End Mountopt3.
+Definition Mountopt3 := struct.decl [
+  "P" :: struct.ptrT Mount3
+].
 
-Module Groups3.
-  Definition S := struct.decl [
-    "Gr_name" :: Name3;
-    "Gr_next" :: refT anyT
-  ].
-End Groups3.
+Definition Groups3 := struct.decl [
+  "Gr_name" :: Name3;
+  "Gr_next" :: refT anyT
+].
 
-Module Exports3.
-  Definition S := struct.decl [
-    "Ex_dir" :: Dirpath3;
-    "Ex_groups" :: struct.ptrT Groups3.S;
-    "Ex_next" :: refT anyT
-  ].
-End Exports3.
+Definition Exports3 := struct.decl [
+  "Ex_dir" :: Dirpath3;
+  "Ex_groups" :: struct.ptrT Groups3;
+  "Ex_next" :: refT anyT
+].
 
-Module Exportsopt3.
-  Definition S := struct.decl [
-    "P" :: struct.ptrT Exports3.S
-  ].
-End Exportsopt3.
+Definition Exportsopt3 := struct.decl [
+  "P" :: struct.ptrT Exports3
+].

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -11,10 +11,8 @@ From Goose Require github_com.tchajed.marshal.
 (* This struct is very important.
 
    This is despite it being empty. *)
-Module importantStruct.
-  Definition S := struct.decl [
-  ].
-End importantStruct.
+Definition importantStruct := struct.decl [
+].
 
 (* doSubtleThings does a number of subtle things:
 
@@ -210,11 +208,9 @@ Definition getRandom: val :=
 
 (* disk.go *)
 
-Module diskWrapper.
-  Definition S := struct.decl [
-    "d" :: disk.Disk
-  ].
-End diskWrapper.
+Definition diskWrapper := struct.decl [
+  "d" :: disk.Disk
+].
 
 Definition diskArgument: val :=
   rec: "diskArgument" "d" :=
@@ -233,16 +229,14 @@ Definition emptyReturn: val :=
 
 (* encoding.go *)
 
-Module Enc.
-  Definition S := struct.decl [
-    "p" :: slice.T byteT
-  ].
-End Enc.
+Definition Enc := struct.decl [
+  "p" :: slice.T byteT
+].
 
 Definition Enc__consume: val :=
   rec: "Enc__consume" "e" "n" :=
-    let: "b" := SliceTake (struct.loadF Enc.S "p" "e") "n" in
-    struct.storeF Enc.S "p" "e" (SliceSkip byteT (struct.loadF Enc.S "p" "e") "n");;
+    let: "b" := SliceTake (struct.loadF Enc "p" "e") "n" in
+    struct.storeF Enc "p" "e" (SliceSkip byteT (struct.loadF Enc "p" "e") "n");;
     "b".
 
 Definition Enc__UInt64: val :=
@@ -253,16 +247,14 @@ Definition Enc__UInt32: val :=
   rec: "Enc__UInt32" "e" "x" :=
     UInt32Put (Enc__consume "e" #4) "x".
 
-Module Dec.
-  Definition S := struct.decl [
-    "p" :: slice.T byteT
-  ].
-End Dec.
+Definition Dec := struct.decl [
+  "p" :: slice.T byteT
+].
 
 Definition Dec__consume: val :=
   rec: "Dec__consume" "d" "n" :=
-    let: "b" := SliceTake (struct.loadF Dec.S "p" "d") "n" in
-    struct.storeF Dec.S "p" "d" (SliceSkip byteT (struct.loadF Dec.S "p" "d") "n");;
+    let: "b" := SliceTake (struct.loadF Dec "p" "d") "n" in
+    struct.storeF Dec "p" "d" (SliceSkip byteT (struct.loadF Dec "p" "d") "n");;
     "b".
 
 Definition Dec__UInt64: val :=
@@ -292,17 +284,15 @@ Definition ConstWithAbbrevType : expr := #(U32 3).
 
 (* literals.go *)
 
-Module allTheLiterals.
-  Definition S := struct.decl [
-    "int" :: uint64T;
-    "s" :: stringT;
-    "b" :: boolT
-  ].
-End allTheLiterals.
+Definition allTheLiterals := struct.decl [
+  "int" :: uint64T;
+  "s" :: stringT;
+  "b" :: boolT
+].
 
 Definition normalLiterals: val :=
   rec: "normalLiterals" <> :=
-    struct.mk allTheLiterals.S [
+    struct.mk allTheLiterals [
       "int" ::= #0;
       "s" ::= #(str"foo");
       "b" ::= #true
@@ -310,7 +300,7 @@ Definition normalLiterals: val :=
 
 Definition specialLiterals: val :=
   rec: "specialLiterals" <> :=
-    struct.mk allTheLiterals.S [
+    struct.mk allTheLiterals [
       "int" ::= #4096;
       "s" ::= #(str"");
       "b" ::= #false
@@ -318,7 +308,7 @@ Definition specialLiterals: val :=
 
 Definition oddLiterals: val :=
   rec: "oddLiterals" <> :=
-    struct.mk allTheLiterals.S [
+    struct.mk allTheLiterals [
       "int" ::= #5;
       "s" ::= #(str"backquote string");
       "b" ::= #false
@@ -341,11 +331,9 @@ Definition useCondVar: val :=
     lock.condWait "c";;
     lock.release "m".
 
-Module hasCondVar.
-  Definition S := struct.decl [
-    "cond" :: condvarRefT
-  ].
-End hasCondVar.
+Definition hasCondVar := struct.decl [
+  "cond" :: condvarRefT
+].
 
 (* log_debugging.go *)
 
@@ -557,16 +545,14 @@ Definition AssignOps: val :=
 
 (* unittest has two package comments *)
 
-Module wrapExternalStruct.
-  Definition S := struct.decl [
-    "e" :: struct.t marshal.Enc.S;
-    "d" :: struct.t marshal.Dec.S
-  ].
-End wrapExternalStruct.
+Definition wrapExternalStruct := struct.decl [
+  "e" :: struct.t marshal.Enc;
+  "d" :: struct.t marshal.Dec
+].
 
 Definition wrapExternalStruct__moveUint64: val :=
   rec: "wrapExternalStruct__moveUint64" "w" :=
-    marshal.Enc__PutInt (struct.get wrapExternalStruct.S "e" "w") (marshal.Dec__GetInt (struct.get wrapExternalStruct.S "d" "w")).
+    marshal.Enc__PutInt (struct.get wrapExternalStruct "e" "w") (marshal.Dec__GetInt (struct.get wrapExternalStruct "d" "w")).
 
 (* panic.go *)
 
@@ -576,35 +562,31 @@ Definition PanicAtTheDisco: val :=
 
 (* reassign.go *)
 
-Module composite.
-  Definition S := struct.decl [
-    "a" :: uint64T;
-    "b" :: uint64T
-  ].
-End composite.
+Definition composite := struct.decl [
+  "a" :: uint64T;
+  "b" :: uint64T
+].
 
 Definition ReassignVars: val :=
   rec: "ReassignVars" <> :=
     let: "x" := ref (zero_val uint64T) in
     let: "y" := #0 in
     "x" <-[uint64T] #3;;
-    let: "z" := ref_to (struct.t composite.S) (struct.mk composite.S [
+    let: "z" := ref_to (struct.t composite) (struct.mk composite [
       "a" ::= ![uint64T] "x";
       "b" ::= "y"
     ]) in
-    "z" <-[struct.t composite.S] struct.mk composite.S [
+    "z" <-[struct.t composite] struct.mk composite [
       "a" ::= "y";
       "b" ::= ![uint64T] "x"
     ];;
-    "x" <-[uint64T] struct.get composite.S "a" (![struct.t composite.S] "z").
+    "x" <-[uint64T] struct.get composite "a" (![struct.t composite] "z").
 
 (* replicated_disk.go *)
 
-Module Block.
-  Definition S := struct.decl [
-    "Value" :: uint64T
-  ].
-End Block.
+Definition Block := struct.decl [
+  "Value" :: uint64T
+].
 
 Definition Disk1 : expr := #0.
 
@@ -620,7 +602,7 @@ Definition TwoDiskWrite: val :=
 (* TwoDiskRead is a dummy function to represent the base layer's disk read *)
 Definition TwoDiskRead: val :=
   rec: "TwoDiskRead" "diskId" "a" :=
-    (struct.mk Block.S [
+    (struct.mk Block [
        "Value" ::= #0
      ], #true).
 
@@ -689,21 +671,17 @@ Definition makeSingletonSlice: val :=
   rec: "makeSingletonSlice" "x" :=
     SliceSingleton "x".
 
-Module thing.
-  Definition S := struct.decl [
-    "x" :: uint64T
-  ].
-End thing.
+Definition thing := struct.decl [
+  "x" :: uint64T
+].
 
-Module sliceOfThings.
-  Definition S := struct.decl [
-    "things" :: slice.T (struct.t thing.S)
-  ].
-End sliceOfThings.
+Definition sliceOfThings := struct.decl [
+  "things" :: slice.T (struct.t thing)
+].
 
 Definition sliceOfThings__getThingRef: val :=
   rec: "sliceOfThings__getThingRef" "ts" "i" :=
-    SliceRef (struct.get sliceOfThings.S "things" "ts") "i".
+    SliceRef (struct.get sliceOfThings "things" "ts") "i".
 
 Definition makeAlias: val :=
   rec: "makeAlias" <> :=
@@ -760,26 +738,24 @@ Definition stringLength: val :=
 
 (* struct_method.go *)
 
-Module Point.
-  Definition S := struct.decl [
-    "x" :: uint64T;
-    "y" :: uint64T
-  ].
-End Point.
+Definition Point := struct.decl [
+  "x" :: uint64T;
+  "y" :: uint64T
+].
 
 Definition Point__Add: val :=
   rec: "Point__Add" "c" "z" :=
-    struct.get Point.S "x" "c" + struct.get Point.S "y" "c" + "z".
+    struct.get Point "x" "c" + struct.get Point "y" "c" + "z".
 
 Definition Point__GetField: val :=
   rec: "Point__GetField" "c" :=
-    let: "x" := struct.get Point.S "x" "c" in
-    let: "y" := struct.get Point.S "y" "c" in
+    let: "x" := struct.get Point "x" "c" in
+    let: "y" := struct.get Point "y" "c" in
     "x" + "y".
 
 Definition UseAdd: val :=
   rec: "UseAdd" <> :=
-    let: "c" := struct.mk Point.S [
+    let: "c" := struct.mk Point [
       "x" ::= #2;
       "y" ::= #3
     ] in
@@ -788,7 +764,7 @@ Definition UseAdd: val :=
 
 Definition UseAddWithLiteral: val :=
   rec: "UseAddWithLiteral" <> :=
-    let: "r" := Point__Add (struct.mk Point.S [
+    let: "r" := Point__Add (struct.mk Point [
       "x" ::= #2;
       "y" ::= #3
     ]) #4 in
@@ -796,26 +772,22 @@ Definition UseAddWithLiteral: val :=
 
 (* struct_pointers.go *)
 
-Module TwoInts.
-  Definition S := struct.decl [
-    "x" :: uint64T;
-    "y" :: uint64T
-  ].
-End TwoInts.
+Definition TwoInts := struct.decl [
+  "x" :: uint64T;
+  "y" :: uint64T
+].
 
-Module S.
-  Definition S := struct.decl [
-    "a" :: uint64T;
-    "b" :: struct.t TwoInts.S;
-    "c" :: boolT
-  ].
-End S.
+Definition S := struct.decl [
+  "a" :: uint64T;
+  "b" :: struct.t TwoInts;
+  "c" :: boolT
+].
 
 Definition NewS: val :=
   rec: "NewS" <> :=
-    struct.new S.S [
+    struct.new S [
       "a" ::= #2;
-      "b" ::= struct.mk TwoInts.S [
+      "b" ::= struct.mk TwoInts [
         "x" ::= #1;
         "y" ::= #2
       ];
@@ -824,39 +796,39 @@ Definition NewS: val :=
 
 Definition S__readA: val :=
   rec: "S__readA" "s" :=
-    struct.loadF S.S "a" "s".
+    struct.loadF S "a" "s".
 
 Definition S__readB: val :=
   rec: "S__readB" "s" :=
-    struct.loadF S.S "b" "s".
+    struct.loadF S "b" "s".
 
 Definition S__readBVal: val :=
   rec: "S__readBVal" "s" :=
-    struct.get S.S "b" "s".
+    struct.get S "b" "s".
 
 Definition S__writeB: val :=
   rec: "S__writeB" "s" "two" :=
-    struct.storeF S.S "b" "s" "two".
+    struct.storeF S "b" "s" "two".
 
 Definition S__negateC: val :=
   rec: "S__negateC" "s" :=
-    struct.storeF S.S "c" "s" (~ (struct.loadF S.S "c" "s")).
+    struct.storeF S "c" "s" (~ (struct.loadF S "c" "s")).
 
 Definition S__refC: val :=
   rec: "S__refC" "s" :=
-    struct.fieldRef S.S "c" "s".
+    struct.fieldRef S "c" "s".
 
 Definition localSRef: val :=
   rec: "localSRef" <> :=
-    let: "s" := ref (zero_val (struct.t S.S)) in
-    struct.fieldRef S.S "b" "s".
+    let: "s" := ref (zero_val (struct.t S)) in
+    struct.fieldRef S "b" "s".
 
 Definition setField: val :=
   rec: "setField" <> :=
-    let: "s" := ref (zero_val (struct.t S.S)) in
-    struct.storeF S.S "a" "s" #0;;
-    struct.storeF S.S "c" "s" #true;;
-    ![struct.t S.S] "s".
+    let: "s" := ref (zero_val (struct.t S)) in
+    struct.storeF S "a" "s" #0;;
+    struct.storeF S "c" "s" #true;;
+    ![struct.t S] "s".
 
 (* synchronization.go *)
 


### PR DESCRIPTION
Structs are now transalted directly as Coq `Definition`s without being enclosed in a `Module`. I updated the gold output, and managed to `make lite` perennial after updating all of the code; if these changes look good to you, I'll push the changes to Perennial as well.