### PR TITLE
add Assume and Assert to machine primitives

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -617,6 +617,10 @@ func (ctx Ctx) packageMethod(f *ast.SelectorExpr,
 			return ctx.newCoqCall("uint64_to_string", args)
 		case "Linearize":
 			return coq.GallinaIdent("Linearize")
+		case "Assume":
+			return ctx.newCoqCall("control.impl.Assume", args)
+		case "Assert":
+			return ctx.newCoqCall("control.impl.Assert", args)
 		default:
 			ctx.futureWork(f, "unhandled call to machine.%s", f.Sel.Name)
 			return coq.CallExpr{}

--- a/machine/prims.go
+++ b/machine/prims.go
@@ -59,3 +59,25 @@ func UInt64ToString(x uint64) string {
 // the sake of executing a simulation fancy update at the linearization point of
 // a procedure..
 func Linearize() {}
+
+// Assume lets the proof assume that `c` is true.
+// *Use with care*, assumptions are trusted and should be justified!
+//
+// The Go implementation will panic (quit the process in a controlled manner) if
+// `c` is not true. (Not to be confused with GooseLang `Panic` which is UB.)
+// In GooseLang, it will loop infinitely.
+func Assume(c bool) {
+	if !c {
+		panic("Assume condition violated")
+	}
+}
+
+// Assert induces a proof obligation that `c` is true.
+//
+// The Go implementation will panic (quit the process in a controlled manner) if
+// `c` is not true. In GooseLang, it will make the machine stuck, i.e., cause UB.
+func Assert(c bool) {
+	if !c {
+		panic("Assert condition violated")
+	}
+}


### PR DESCRIPTION
As discussed with @upamanyus and @jtassarotti, it would be nice to have an explicit way to "assume" something in Goose'd code.

(`Assert` would probably also make sense but we didn't need that yet.)