### PR TITLE
better handling of nested conditionals that early return

### DIFF
--- a/internal/examples/simpledb/simpledb.gold.v
+++ b/internal/examples/simpledb/simpledb.gold.v
@@ -114,8 +114,7 @@ Definition readTableIndex: val :=
             "offset" ::= struct.get lazyFileBuf "offset" (![struct.t lazyFileBuf] "buf");
             "next" ::= "newBuf"
           ];;
-          Continue));;
-      Continue).
+          Continue))).
 
 (* RecoverTable restores a table from disk on startup. *)
 Definition RecoverTable: val :=
@@ -379,8 +378,7 @@ Definition tablePutOldTable: val :=
             "offset" ::= struct.get lazyFileBuf "offset" (![struct.t lazyFileBuf] "buf");
             "next" ::= "newBuf"
           ];;
-          Continue));;
-      Continue).
+          Continue))).
 
 (* Build a new shadow table that incorporates the current table and a
    (write) buffer wbuf.

--- a/internal/examples/unittest/loops.go
+++ b/internal/examples/unittest/loops.go
@@ -35,6 +35,17 @@ func conditionalInLoop() {
 	}
 }
 
+func conditionalInLoopElse() {
+	for i := uint64(0); ; {
+		if i > 5 {
+			break
+		} else {
+			i = i + 1
+			continue
+		}
+	}
+}
+
 func ImplicitLoopContinue() {
 	for i := uint64(0); ; {
 		if i < 4 {

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -387,6 +387,16 @@ Definition conditionalInLoop: val :=
         "i" <-[uint64T] ![uint64T] "i" + #1;;
         Continue)).
 
+Definition conditionalInLoopElse: val :=
+  rec: "conditionalInLoopElse" <> :=
+    let: "i" := ref_to uint64T #0 in
+    (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
+      (if: ![uint64T] "i" > #5
+      then Break
+      else
+        "i" <-[uint64T] ![uint64T] "i" + #1;;
+        Continue)).
+
 Definition ImplicitLoopContinue: val :=
   rec: "ImplicitLoopContinue" <> :=
     let: "i" := ref_to uint64T #0 in

--- a/testdata/negative-tests/badif1.go
+++ b/testdata/negative-tests/badif1.go
@@ -2,7 +2,7 @@ package example
 
 func Skip() {}
 
-func BadLoop(i uint64) {
+func BadIf(i uint64) {
 	if i == 0 {
 		return
 	} else { // ERROR else with early return

--- a/testdata/negative-tests/badif2.go
+++ b/testdata/negative-tests/badif2.go
@@ -1,0 +1,14 @@
+package example
+
+func Skip() {}
+
+func BadIf2(i uint64) {
+	if i == 0 {
+		if true {
+			return // ERROR nested if statement branches differ on whether they return
+		} else {
+			Skip()
+		}
+	}
+	Skip()
+}

--- a/testdata/negative-tests/badloop1.go
+++ b/testdata/negative-tests/badloop1.go
@@ -1,0 +1,12 @@
+package example
+
+func Skip() bool { return false }
+
+func BadLoop(i uint64) {
+	// This used to translate incorrectly, into a loop that always `Continue`s.
+	for {
+		if !Skip() { // ERROR nested if statement branches differ on whether they return
+			break
+		}
+	}
+}


### PR DESCRIPTION
This fixes translation of functions like the `conditionalInLoopElse` that I added, by improving the analysis performed by `endsWithReturn`. "simpledb" output also changes; I think the old output was wrong.

I am not sure how to run the "testdata/negative-tests", so the new test I added might not work. All I know is that `go test` passes but that does not seem to run those particular tests.

I don't actually know what I am doing here, so some or all of this might be utter nonsense.^^