### PR TITLE
Use opaque pointer type

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -180,23 +180,23 @@ func TestSimpleDb(t *testing.T) {
 }
 
 func TestWal(t *testing.T) {
-	testExample(t, "wal", goose.Translator{TypeCheck: true})
+	testExample(t, "wal", goose.Translator{})
 }
 
 func TestLogging2(t *testing.T) {
-	testExample(t, "logging2", goose.Translator{TypeCheck: true})
+	testExample(t, "logging2", goose.Translator{})
 }
 
 func TestAppendLog(t *testing.T) {
-	testExample(t, "append_log", goose.Translator{TypeCheck: true})
+	testExample(t, "append_log", goose.Translator{})
 }
 
 func TestRfc1813(t *testing.T) {
-	testExample(t, "rfc1813", goose.Translator{TypeCheck: true})
+	testExample(t, "rfc1813", goose.Translator{})
 }
 
 func TestSemantics(t *testing.T) {
-	testExample(t, "semantics", goose.Translator{TypeCheck: true})
+	testExample(t, "semantics", goose.Translator{})
 }
 
 func TestComments(t *testing.T) {

--- a/goose.go
+++ b/goose.go
@@ -219,11 +219,6 @@ func (ctx Ctx) structFields(structName string,
 			return nil
 		}
 		ty := ctx.coqType(f.Type)
-		info, ok := ctx.getStructInfo(ctx.typeOf(f.Type))
-		if ok && info.name == structName && info.throughPointer {
-			// TODO: Remove reference to refT, use indirection in coq.go
-			ty = coq.NewCallExpr("refT", coq.TypeIdent("anyT"))
-		}
 		decls = append(decls, coq.FieldDecl{
 			Name: f.Names[0].Name,
 			Type: ty,
@@ -553,7 +548,7 @@ func (ctx Ctx) newExpr(s ast.Node, ty ast.Expr) coq.CallExpr {
 	}
 	e := coq.NewCallExpr("zero_val", ctx.coqType(ty))
 	// check for new(T) where T is a struct, but not a pointer to a struct
-	// (new(*T) should be translated to ref (zero_val (ptrT ...)) as usual,
+	// (new(*T) should be translated to ref (zero_val ptrT) as usual,
 	// a pointer to a nil pointer)
 	if info, ok := ctx.getStructInfo(ctx.typeOf(ty)); ok && !info.throughPointer {
 		return coq.NewCallExpr("struct.alloc", coq.StructDesc(info.name), e)

--- a/internal/coq/coq.go
+++ b/internal/coq/coq.go
@@ -1081,11 +1081,10 @@ func (tt TupleType) Coq() string {
 }
 
 type PtrType struct {
-	Value Type
 }
 
 func (t PtrType) Coq() string {
-	return NewCallExpr("refT", t.Value).Coq()
+	return "ptrT"
 }
 
 func StructMethod(structName string, methodName string) string {

--- a/internal/examples/append_log/append_log.gold.v
+++ b/internal/examples/append_log/append_log.gold.v
@@ -11,7 +11,7 @@ From Goose Require github_com.tchajed.marshal.
    the number of valid blocks in the log. *)
 
 Definition Log := struct.decl [
-  "m" :: lockRefT;
+  "m" :: ptrT;
   "sz" :: uint64T;
   "diskSz" :: uint64T
 ].
@@ -22,17 +22,11 @@ Definition Log__mkHdr: val :=
     marshal.Enc__PutInt "enc" (struct.loadF Log "sz" "log");;
     marshal.Enc__PutInt "enc" (struct.loadF Log "diskSz" "log");;
     marshal.Enc__Finish "enc".
-Theorem Log__mkHdr_t: ⊢ Log__mkHdr : (struct.ptrT Log -> disk.blockT).
-Proof. typecheck. Qed.
-Hint Resolve Log__mkHdr_t : types.
 
 Definition Log__writeHdr: val :=
   rec: "Log__writeHdr" "log" :=
     disk.Write #0 (Log__mkHdr "log");;
     #().
-Theorem Log__writeHdr_t: ⊢ Log__writeHdr : (struct.ptrT Log -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Log__writeHdr_t : types.
 
 Definition Init: val :=
   rec: "Init" "diskSz" :=
@@ -51,9 +45,6 @@ Definition Init: val :=
       ] in
       Log__writeHdr "log";;
       ("log", #true)).
-Theorem Init_t: ⊢ Init : (uint64T -> (struct.ptrT Log * boolT)).
-Proof. typecheck. Qed.
-Hint Resolve Init_t : types.
 
 Definition Open: val :=
   rec: "Open" <> :=
@@ -66,9 +57,6 @@ Definition Open: val :=
       "sz" ::= "sz";
       "diskSz" ::= "diskSz"
     ].
-Theorem Open_t: ⊢ Open : (unitT -> struct.ptrT Log).
-Proof. typecheck. Qed.
-Hint Resolve Open_t : types.
 
 Definition Log__get: val :=
   rec: "Log__get" "log" "i" :=
@@ -76,9 +64,6 @@ Definition Log__get: val :=
     (if: "i" < "sz"
     then (disk.Read (#1 + "i"), #true)
     else (slice.nil, #false)).
-Theorem Log__get_t: ⊢ Log__get : (struct.ptrT Log -> uint64T -> (disk.blockT * boolT)).
-Proof. typecheck. Qed.
-Hint Resolve Log__get_t : types.
 
 Definition Log__Get: val :=
   rec: "Log__Get" "log" "i" :=
@@ -86,18 +71,12 @@ Definition Log__Get: val :=
     let: ("v", "b") := Log__get "log" "i" in
     lock.release (struct.loadF Log "m" "log");;
     ("v", "b").
-Theorem Log__Get_t: ⊢ Log__Get : (struct.ptrT Log -> uint64T -> (disk.blockT * boolT)).
-Proof. typecheck. Qed.
-Hint Resolve Log__Get_t : types.
 
 Definition writeAll: val :=
   rec: "writeAll" "bks" "off" :=
     ForSlice (slice.T byteT) "i" "bk" "bks"
       (disk.Write ("off" + "i") "bk");;
     #().
-Theorem writeAll_t: ⊢ writeAll : (slice.T disk.blockT -> uint64T -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve writeAll_t : types.
 
 Definition Log__append: val :=
   rec: "Log__append" "log" "bks" :=
@@ -109,9 +88,6 @@ Definition Log__append: val :=
       struct.storeF Log "sz" "log" (struct.loadF Log "sz" "log" + slice.len "bks");;
       Log__writeHdr "log";;
       #true).
-Theorem Log__append_t: ⊢ Log__append : (struct.ptrT Log -> slice.T disk.blockT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve Log__append_t : types.
 
 Definition Log__Append: val :=
   rec: "Log__Append" "log" "bks" :=
@@ -119,18 +95,12 @@ Definition Log__Append: val :=
     let: "b" := Log__append "log" "bks" in
     lock.release (struct.loadF Log "m" "log");;
     "b".
-Theorem Log__Append_t: ⊢ Log__Append : (struct.ptrT Log -> slice.T disk.blockT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve Log__Append_t : types.
 
 Definition Log__reset: val :=
   rec: "Log__reset" "log" :=
     struct.storeF Log "sz" "log" #0;;
     Log__writeHdr "log";;
     #().
-Theorem Log__reset_t: ⊢ Log__reset : (struct.ptrT Log -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Log__reset_t : types.
 
 Definition Log__Reset: val :=
   rec: "Log__Reset" "log" :=
@@ -138,6 +108,3 @@ Definition Log__Reset: val :=
     Log__reset "log";;
     lock.release (struct.loadF Log "m" "log");;
     #().
-Theorem Log__Reset_t: ⊢ Log__Reset : (struct.ptrT Log -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Log__Reset_t : types.

--- a/internal/examples/rfc1813/rfc1813.gold.v
+++ b/internal/examples/rfc1813/rfc1813.gold.v
@@ -5,28 +5,16 @@ Context `{ext_ty: ext_types}.
 Local Coercion Var' s: expr := Var s.
 
 Definition PROGRAM : expr := #(U32 100003).
-Theorem PROGRAM_t Γ : Γ ⊢ PROGRAM : uint32T.
-Proof. typecheck. Qed.
 
 Definition VERSION : expr := #(U32 3).
-Theorem VERSION_t Γ : Γ ⊢ VERSION : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFS3_FHSIZE : expr := #(U32 64).
-Theorem NFS3_FHSIZE_t Γ : Γ ⊢ NFS3_FHSIZE : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFS3_COOKIEVERFSIZE : expr := #(U32 8).
-Theorem NFS3_COOKIEVERFSIZE_t Γ : Γ ⊢ NFS3_COOKIEVERFSIZE : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFS3_CREATEVERFSIZE : expr := #(U32 8).
-Theorem NFS3_CREATEVERFSIZE_t Γ : Γ ⊢ NFS3_CREATEVERFSIZE : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFS3_WRITEVERFSIZE : expr := #(U32 8).
-Theorem NFS3_WRITEVERFSIZE_t Γ : Γ ⊢ NFS3_WRITEVERFSIZE : uint32T.
-Proof. typecheck. Qed.
 
 Definition Uint64: ty := uint64T.
 
@@ -61,150 +49,78 @@ Definition Count3: ty := Uint32.
 Definition Nfsstat3: ty := uint32T.
 
 Definition NFS3_OK : expr := #(U32 0).
-Theorem NFS3_OK_t Γ : Γ ⊢ NFS3_OK : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_PERM : expr := #(U32 1).
-Theorem NFS3ERR_PERM_t Γ : Γ ⊢ NFS3ERR_PERM : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_NOENT : expr := #(U32 2).
-Theorem NFS3ERR_NOENT_t Γ : Γ ⊢ NFS3ERR_NOENT : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_IO : expr := #(U32 5).
-Theorem NFS3ERR_IO_t Γ : Γ ⊢ NFS3ERR_IO : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_NXIO : expr := #(U32 6).
-Theorem NFS3ERR_NXIO_t Γ : Γ ⊢ NFS3ERR_NXIO : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_ACCES : expr := #(U32 13).
-Theorem NFS3ERR_ACCES_t Γ : Γ ⊢ NFS3ERR_ACCES : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_EXIST : expr := #(U32 17).
-Theorem NFS3ERR_EXIST_t Γ : Γ ⊢ NFS3ERR_EXIST : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_XDEV : expr := #(U32 18).
-Theorem NFS3ERR_XDEV_t Γ : Γ ⊢ NFS3ERR_XDEV : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_NODEV : expr := #(U32 19).
-Theorem NFS3ERR_NODEV_t Γ : Γ ⊢ NFS3ERR_NODEV : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_NOTDIR : expr := #(U32 20).
-Theorem NFS3ERR_NOTDIR_t Γ : Γ ⊢ NFS3ERR_NOTDIR : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_ISDIR : expr := #(U32 21).
-Theorem NFS3ERR_ISDIR_t Γ : Γ ⊢ NFS3ERR_ISDIR : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_INVAL : expr := #(U32 22).
-Theorem NFS3ERR_INVAL_t Γ : Γ ⊢ NFS3ERR_INVAL : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_FBIG : expr := #(U32 27).
-Theorem NFS3ERR_FBIG_t Γ : Γ ⊢ NFS3ERR_FBIG : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_NOSPC : expr := #(U32 28).
-Theorem NFS3ERR_NOSPC_t Γ : Γ ⊢ NFS3ERR_NOSPC : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_ROFS : expr := #(U32 30).
-Theorem NFS3ERR_ROFS_t Γ : Γ ⊢ NFS3ERR_ROFS : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_MLINK : expr := #(U32 31).
-Theorem NFS3ERR_MLINK_t Γ : Γ ⊢ NFS3ERR_MLINK : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_NAMETOOLONG : expr := #(U32 63).
-Theorem NFS3ERR_NAMETOOLONG_t Γ : Γ ⊢ NFS3ERR_NAMETOOLONG : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_NOTEMPTY : expr := #(U32 66).
-Theorem NFS3ERR_NOTEMPTY_t Γ : Γ ⊢ NFS3ERR_NOTEMPTY : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_DQUOT : expr := #(U32 69).
-Theorem NFS3ERR_DQUOT_t Γ : Γ ⊢ NFS3ERR_DQUOT : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_STALE : expr := #(U32 70).
-Theorem NFS3ERR_STALE_t Γ : Γ ⊢ NFS3ERR_STALE : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_REMOTE : expr := #(U32 71).
-Theorem NFS3ERR_REMOTE_t Γ : Γ ⊢ NFS3ERR_REMOTE : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_BADHANDLE : expr := #(U32 10001).
-Theorem NFS3ERR_BADHANDLE_t Γ : Γ ⊢ NFS3ERR_BADHANDLE : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_NOT_SYNC : expr := #(U32 10002).
-Theorem NFS3ERR_NOT_SYNC_t Γ : Γ ⊢ NFS3ERR_NOT_SYNC : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_BAD_COOKIE : expr := #(U32 10003).
-Theorem NFS3ERR_BAD_COOKIE_t Γ : Γ ⊢ NFS3ERR_BAD_COOKIE : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_NOTSUPP : expr := #(U32 10004).
-Theorem NFS3ERR_NOTSUPP_t Γ : Γ ⊢ NFS3ERR_NOTSUPP : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_TOOSMALL : expr := #(U32 10005).
-Theorem NFS3ERR_TOOSMALL_t Γ : Γ ⊢ NFS3ERR_TOOSMALL : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_SERVERFAULT : expr := #(U32 10006).
-Theorem NFS3ERR_SERVERFAULT_t Γ : Γ ⊢ NFS3ERR_SERVERFAULT : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_BADTYPE : expr := #(U32 10007).
-Theorem NFS3ERR_BADTYPE_t Γ : Γ ⊢ NFS3ERR_BADTYPE : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition NFS3ERR_JUKEBOX : expr := #(U32 10008).
-Theorem NFS3ERR_JUKEBOX_t Γ : Γ ⊢ NFS3ERR_JUKEBOX : Nfsstat3.
-Proof. typecheck. Qed.
 
 Definition Ftype3: ty := uint32T.
 
 Definition NF3REG : expr := #(U32 1).
-Theorem NF3REG_t Γ : Γ ⊢ NF3REG : Ftype3.
-Proof. typecheck. Qed.
 
 Definition NF3DIR : expr := #(U32 2).
-Theorem NF3DIR_t Γ : Γ ⊢ NF3DIR : Ftype3.
-Proof. typecheck. Qed.
 
 Definition NF3BLK : expr := #(U32 3).
-Theorem NF3BLK_t Γ : Γ ⊢ NF3BLK : Ftype3.
-Proof. typecheck. Qed.
 
 Definition NF3CHR : expr := #(U32 4).
-Theorem NF3CHR_t Γ : Γ ⊢ NF3CHR : Ftype3.
-Proof. typecheck. Qed.
 
 Definition NF3LNK : expr := #(U32 5).
-Theorem NF3LNK_t Γ : Γ ⊢ NF3LNK : Ftype3.
-Proof. typecheck. Qed.
 
 Definition NF3SOCK : expr := #(U32 6).
-Theorem NF3SOCK_t Γ : Γ ⊢ NF3SOCK : Ftype3.
-Proof. typecheck. Qed.
 
 Definition NF3FIFO : expr := #(U32 7).
-Theorem NF3FIFO_t Γ : Γ ⊢ NF3FIFO : Ftype3.
-Proof. typecheck. Qed.
 
 Definition Specdata3 := struct.decl [
   "Specdata1" :: Uint32;
@@ -265,16 +181,10 @@ Definition Post_op_fh3 := struct.decl [
 Definition Time_how: ty := uint32T.
 
 Definition DONT_CHANGE : expr := #(U32 0).
-Theorem DONT_CHANGE_t Γ : Γ ⊢ DONT_CHANGE : Time_how.
-Proof. typecheck. Qed.
 
 Definition SET_TO_SERVER_TIME : expr := #(U32 1).
-Theorem SET_TO_SERVER_TIME_t Γ : Γ ⊢ SET_TO_SERVER_TIME : Time_how.
-Proof. typecheck. Qed.
 
 Definition SET_TO_CLIENT_TIME : expr := #(U32 2).
-Theorem SET_TO_CLIENT_TIME_t Γ : Γ ⊢ SET_TO_CLIENT_TIME : Time_how.
-Proof. typecheck. Qed.
 
 Definition Set_mode3 := struct.decl [
   "Set_it" :: boolT;
@@ -321,100 +231,52 @@ Definition Diropargs3 := struct.decl [
 ].
 
 Definition NFS_PROGRAM : expr := #(U32 100003).
-Theorem NFS_PROGRAM_t Γ : Γ ⊢ NFS_PROGRAM : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFS_V3 : expr := #(U32 3).
-Theorem NFS_V3_t Γ : Γ ⊢ NFS_V3 : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_NULL : expr := #(U32 0).
-Theorem NFSPROC3_NULL_t Γ : Γ ⊢ NFSPROC3_NULL : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_GETATTR : expr := #(U32 1).
-Theorem NFSPROC3_GETATTR_t Γ : Γ ⊢ NFSPROC3_GETATTR : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_SETATTR : expr := #(U32 2).
-Theorem NFSPROC3_SETATTR_t Γ : Γ ⊢ NFSPROC3_SETATTR : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_LOOKUP : expr := #(U32 3).
-Theorem NFSPROC3_LOOKUP_t Γ : Γ ⊢ NFSPROC3_LOOKUP : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_ACCESS : expr := #(U32 4).
-Theorem NFSPROC3_ACCESS_t Γ : Γ ⊢ NFSPROC3_ACCESS : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_READLINK : expr := #(U32 5).
-Theorem NFSPROC3_READLINK_t Γ : Γ ⊢ NFSPROC3_READLINK : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_READ : expr := #(U32 6).
-Theorem NFSPROC3_READ_t Γ : Γ ⊢ NFSPROC3_READ : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_WRITE : expr := #(U32 7).
-Theorem NFSPROC3_WRITE_t Γ : Γ ⊢ NFSPROC3_WRITE : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_CREATE : expr := #(U32 8).
-Theorem NFSPROC3_CREATE_t Γ : Γ ⊢ NFSPROC3_CREATE : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_MKDIR : expr := #(U32 9).
-Theorem NFSPROC3_MKDIR_t Γ : Γ ⊢ NFSPROC3_MKDIR : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_SYMLINK : expr := #(U32 10).
-Theorem NFSPROC3_SYMLINK_t Γ : Γ ⊢ NFSPROC3_SYMLINK : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_MKNOD : expr := #(U32 11).
-Theorem NFSPROC3_MKNOD_t Γ : Γ ⊢ NFSPROC3_MKNOD : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_REMOVE : expr := #(U32 12).
-Theorem NFSPROC3_REMOVE_t Γ : Γ ⊢ NFSPROC3_REMOVE : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_RMDIR : expr := #(U32 13).
-Theorem NFSPROC3_RMDIR_t Γ : Γ ⊢ NFSPROC3_RMDIR : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_RENAME : expr := #(U32 14).
-Theorem NFSPROC3_RENAME_t Γ : Γ ⊢ NFSPROC3_RENAME : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_LINK : expr := #(U32 15).
-Theorem NFSPROC3_LINK_t Γ : Γ ⊢ NFSPROC3_LINK : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_READDIR : expr := #(U32 16).
-Theorem NFSPROC3_READDIR_t Γ : Γ ⊢ NFSPROC3_READDIR : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_READDIRPLUS : expr := #(U32 17).
-Theorem NFSPROC3_READDIRPLUS_t Γ : Γ ⊢ NFSPROC3_READDIRPLUS : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_FSSTAT : expr := #(U32 18).
-Theorem NFSPROC3_FSSTAT_t Γ : Γ ⊢ NFSPROC3_FSSTAT : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_FSINFO : expr := #(U32 19).
-Theorem NFSPROC3_FSINFO_t Γ : Γ ⊢ NFSPROC3_FSINFO : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_PATHCONF : expr := #(U32 20).
-Theorem NFSPROC3_PATHCONF_t Γ : Γ ⊢ NFSPROC3_PATHCONF : uint32T.
-Proof. typecheck. Qed.
 
 Definition NFSPROC3_COMMIT : expr := #(U32 21).
-Theorem NFSPROC3_COMMIT_t Γ : Γ ⊢ NFSPROC3_COMMIT : uint32T.
-Proof. typecheck. Qed.
 
 Definition GETATTR3args := struct.decl [
   "Object" :: struct.t Nfs_fh3
@@ -475,28 +337,16 @@ Definition LOOKUP3res := struct.decl [
 ].
 
 Definition ACCESS3_READ : expr := #(U32 1).
-Theorem ACCESS3_READ_t Γ : Γ ⊢ ACCESS3_READ : uint32T.
-Proof. typecheck. Qed.
 
 Definition ACCESS3_LOOKUP : expr := #(U32 2).
-Theorem ACCESS3_LOOKUP_t Γ : Γ ⊢ ACCESS3_LOOKUP : uint32T.
-Proof. typecheck. Qed.
 
 Definition ACCESS3_MODIFY : expr := #(U32 4).
-Theorem ACCESS3_MODIFY_t Γ : Γ ⊢ ACCESS3_MODIFY : uint32T.
-Proof. typecheck. Qed.
 
 Definition ACCESS3_EXTEND : expr := #(U32 8).
-Theorem ACCESS3_EXTEND_t Γ : Γ ⊢ ACCESS3_EXTEND : uint32T.
-Proof. typecheck. Qed.
 
 Definition ACCESS3_DELETE : expr := #(U32 16).
-Theorem ACCESS3_DELETE_t Γ : Γ ⊢ ACCESS3_DELETE : uint32T.
-Proof. typecheck. Qed.
 
 Definition ACCESS3_EXECUTE : expr := #(U32 32).
-Theorem ACCESS3_EXECUTE_t Γ : Γ ⊢ ACCESS3_EXECUTE : uint32T.
-Proof. typecheck. Qed.
 
 Definition ACCESS3args := struct.decl [
   "Object" :: struct.t Nfs_fh3;
@@ -563,16 +413,10 @@ Definition READ3res := struct.decl [
 Definition Stable_how: ty := uint32T.
 
 Definition UNSTABLE : expr := #(U32 0).
-Theorem UNSTABLE_t Γ : Γ ⊢ UNSTABLE : Stable_how.
-Proof. typecheck. Qed.
 
 Definition DATA_SYNC : expr := #(U32 1).
-Theorem DATA_SYNC_t Γ : Γ ⊢ DATA_SYNC : Stable_how.
-Proof. typecheck. Qed.
 
 Definition FILE_SYNC : expr := #(U32 2).
-Theorem FILE_SYNC_t Γ : Γ ⊢ FILE_SYNC : Stable_how.
-Proof. typecheck. Qed.
 
 Definition WRITE3args := struct.decl [
   "File" :: struct.t Nfs_fh3;
@@ -602,16 +446,10 @@ Definition WRITE3res := struct.decl [
 Definition Createmode3: ty := uint32T.
 
 Definition UNCHECKED : expr := #(U32 0).
-Theorem UNCHECKED_t Γ : Γ ⊢ UNCHECKED : Createmode3.
-Proof. typecheck. Qed.
 
 Definition GUARDED : expr := #(U32 1).
-Theorem GUARDED_t Γ : Γ ⊢ GUARDED : Createmode3.
-Proof. typecheck. Qed.
 
 Definition EXCLUSIVE : expr := #(U32 2).
-Theorem EXCLUSIVE_t Γ : Γ ⊢ EXCLUSIVE : Createmode3.
-Proof. typecheck. Qed.
 
 Definition Createhow3 := struct.decl [
   "Mode" :: Createmode3;
@@ -808,11 +646,11 @@ Definition Entry3 := struct.decl [
   "Fileid" :: Fileid3;
   "Name" :: Filename3;
   "Cookie" :: Cookie3;
-  "Nextentry" :: refT anyT
+  "Nextentry" :: ptrT
 ].
 
 Definition Dirlist3 := struct.decl [
-  "Entries" :: struct.ptrT Entry3;
+  "Entries" :: ptrT;
   "Eof" :: boolT
 ].
 
@@ -846,11 +684,11 @@ Definition Entryplus3 := struct.decl [
   "Cookie" :: Cookie3;
   "Name_attributes" :: struct.t Post_op_attr;
   "Name_handle" :: struct.t Post_op_fh3;
-  "Nextentry" :: refT anyT
+  "Nextentry" :: ptrT
 ].
 
 Definition Dirlistplus3 := struct.decl [
-  "Entries" :: struct.ptrT Entryplus3;
+  "Entries" :: ptrT;
   "Eof" :: boolT
 ].
 
@@ -896,20 +734,12 @@ Definition FSSTAT3res := struct.decl [
 ].
 
 Definition FSF3_LINK : expr := #(U32 1).
-Theorem FSF3_LINK_t Γ : Γ ⊢ FSF3_LINK : uint32T.
-Proof. typecheck. Qed.
 
 Definition FSF3_SYMLINK : expr := #(U32 2).
-Theorem FSF3_SYMLINK_t Γ : Γ ⊢ FSF3_SYMLINK : uint32T.
-Proof. typecheck. Qed.
 
 Definition FSF3_HOMOGENEOUS : expr := #(U32 8).
-Theorem FSF3_HOMOGENEOUS_t Γ : Γ ⊢ FSF3_HOMOGENEOUS : uint32T.
-Proof. typecheck. Qed.
 
 Definition FSF3_CANSETTIME : expr := #(U32 16).
-Theorem FSF3_CANSETTIME_t Γ : Γ ⊢ FSF3_CANSETTIME : uint32T.
-Proof. typecheck. Qed.
 
 Definition FSINFO3args := struct.decl [
   "Fsroot" :: struct.t Nfs_fh3
@@ -985,16 +815,10 @@ Definition COMMIT3res := struct.decl [
 ].
 
 Definition MNTPATHLEN3 : expr := #(U32 1024).
-Theorem MNTPATHLEN3_t Γ : Γ ⊢ MNTPATHLEN3 : uint32T.
-Proof. typecheck. Qed.
 
 Definition MNTNAMLEN3 : expr := #(U32 255).
-Theorem MNTNAMLEN3_t Γ : Γ ⊢ MNTNAMLEN3 : uint32T.
-Proof. typecheck. Qed.
 
 Definition FHSIZE3 : expr := #(U32 64).
-Theorem FHSIZE3_t Γ : Γ ⊢ FHSIZE3 : uint32T.
-Proof. typecheck. Qed.
 
 Definition Fhandle3: ty := slice.T byteT.
 
@@ -1005,76 +829,40 @@ Definition Name3: ty := stringT.
 Definition Mountstat3: ty := uint32T.
 
 Definition MNT3_OK : expr := #(U32 0).
-Theorem MNT3_OK_t Γ : Γ ⊢ MNT3_OK : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MNT3ERR_PERM : expr := #(U32 1).
-Theorem MNT3ERR_PERM_t Γ : Γ ⊢ MNT3ERR_PERM : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MNT3ERR_NOENT : expr := #(U32 2).
-Theorem MNT3ERR_NOENT_t Γ : Γ ⊢ MNT3ERR_NOENT : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MNT3ERR_IO : expr := #(U32 5).
-Theorem MNT3ERR_IO_t Γ : Γ ⊢ MNT3ERR_IO : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MNT3ERR_ACCES : expr := #(U32 13).
-Theorem MNT3ERR_ACCES_t Γ : Γ ⊢ MNT3ERR_ACCES : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MNT3ERR_NOTDIR : expr := #(U32 20).
-Theorem MNT3ERR_NOTDIR_t Γ : Γ ⊢ MNT3ERR_NOTDIR : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MNT3ERR_INVAL : expr := #(U32 22).
-Theorem MNT3ERR_INVAL_t Γ : Γ ⊢ MNT3ERR_INVAL : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MNT3ERR_NAMETOOLONG : expr := #(U32 63).
-Theorem MNT3ERR_NAMETOOLONG_t Γ : Γ ⊢ MNT3ERR_NAMETOOLONG : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MNT3ERR_NOTSUPP : expr := #(U32 10004).
-Theorem MNT3ERR_NOTSUPP_t Γ : Γ ⊢ MNT3ERR_NOTSUPP : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MNT3ERR_SERVERFAULT : expr := #(U32 10006).
-Theorem MNT3ERR_SERVERFAULT_t Γ : Γ ⊢ MNT3ERR_SERVERFAULT : Mountstat3.
-Proof. typecheck. Qed.
 
 Definition MOUNT_PROGRAM : expr := #(U32 100005).
-Theorem MOUNT_PROGRAM_t Γ : Γ ⊢ MOUNT_PROGRAM : uint32T.
-Proof. typecheck. Qed.
 
 Definition MOUNT_V3 : expr := #(U32 3).
-Theorem MOUNT_V3_t Γ : Γ ⊢ MOUNT_V3 : uint32T.
-Proof. typecheck. Qed.
 
 Definition MOUNTPROC3_NULL : expr := #(U32 0).
-Theorem MOUNTPROC3_NULL_t Γ : Γ ⊢ MOUNTPROC3_NULL : uint32T.
-Proof. typecheck. Qed.
 
 Definition MOUNTPROC3_MNT : expr := #(U32 1).
-Theorem MOUNTPROC3_MNT_t Γ : Γ ⊢ MOUNTPROC3_MNT : uint32T.
-Proof. typecheck. Qed.
 
 Definition MOUNTPROC3_DUMP : expr := #(U32 2).
-Theorem MOUNTPROC3_DUMP_t Γ : Γ ⊢ MOUNTPROC3_DUMP : uint32T.
-Proof. typecheck. Qed.
 
 Definition MOUNTPROC3_UMNT : expr := #(U32 3).
-Theorem MOUNTPROC3_UMNT_t Γ : Γ ⊢ MOUNTPROC3_UMNT : uint32T.
-Proof. typecheck. Qed.
 
 Definition MOUNTPROC3_UMNTALL : expr := #(U32 4).
-Theorem MOUNTPROC3_UMNTALL_t Γ : Γ ⊢ MOUNTPROC3_UMNTALL : uint32T.
-Proof. typecheck. Qed.
 
 Definition MOUNTPROC3_EXPORT : expr := #(U32 5).
-Theorem MOUNTPROC3_EXPORT_t Γ : Γ ⊢ MOUNTPROC3_EXPORT : uint32T.
-Proof. typecheck. Qed.
 
 Definition Mountres3_ok := struct.decl [
   "Fhandle" :: Fhandle3;
@@ -1089,26 +877,26 @@ Definition Mountres3 := struct.decl [
 Definition Mount3 := struct.decl [
   "Ml_hostname" :: Name3;
   "Ml_directory" :: Dirpath3;
-  "Ml_next" :: refT anyT
+  "Ml_next" :: ptrT
 ].
 
 Definition Mountopt3 := struct.decl [
-  "P" :: struct.ptrT Mount3
+  "P" :: ptrT
 ].
 
 Definition Groups3 := struct.decl [
   "Gr_name" :: Name3;
-  "Gr_next" :: refT anyT
+  "Gr_next" :: ptrT
 ].
 
 Definition Exports3 := struct.decl [
   "Ex_dir" :: Dirpath3;
-  "Ex_groups" :: struct.ptrT Groups3;
-  "Ex_next" :: refT anyT
+  "Ex_groups" :: ptrT;
+  "Ex_next" :: ptrT
 ].
 
 Definition Exportsopt3 := struct.decl [
-  "P" :: struct.ptrT Exports3
+  "P" :: ptrT
 ].
 
 End code.

--- a/internal/examples/semantics/semantics.gold.v
+++ b/internal/examples/semantics/semantics.gold.v
@@ -18,18 +18,12 @@ Definition findKey: val :=
         "ok" <-[boolT] #true
       else #()));;
     (![uint64T] "found", ![boolT] "ok").
-Theorem findKey_t: ⊢ findKey : (mapT (struct.t unit) -> (uint64T * boolT)).
-Proof. typecheck. Qed.
-Hint Resolve findKey_t : types.
 
 Definition allocate: val :=
   rec: "allocate" "m" :=
     let: ("k", "ok") := findKey "m" in
     MapDelete "m" "k";;
     ("k", "ok").
-Theorem allocate_t: ⊢ allocate : (mapT (struct.t unit) -> (uint64T * boolT)).
-Proof. typecheck. Qed.
-Hint Resolve allocate_t : types.
 
 Definition freeRange: val :=
   rec: "freeRange" "sz" :=
@@ -40,9 +34,6 @@ Definition freeRange: val :=
       ]);;
       Continue);;
     "m".
-Theorem freeRange_t: ⊢ freeRange : (uint64T -> mapT (struct.t unit)).
-Proof. typecheck. Qed.
-Hint Resolve freeRange_t : types.
 
 Definition testAllocateDistinct: val :=
   rec: "testAllocateDistinct" <> :=
@@ -50,9 +41,6 @@ Definition testAllocateDistinct: val :=
     let: ("a1", <>) := allocate "free" in
     let: ("a2", <>) := allocate "free" in
     "a1" ≠ "a2".
-Theorem testAllocateDistinct_t: ⊢ testAllocateDistinct : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testAllocateDistinct_t : types.
 
 Definition testAllocateFull: val :=
   rec: "testAllocateFull" <> :=
@@ -61,9 +49,6 @@ Definition testAllocateFull: val :=
     let: (<>, "ok2") := allocate "free" in
     let: (<>, "ok3") := allocate "free" in
     ("ok1" && "ok2") && (~ "ok3").
-Theorem testAllocateFull_t: ⊢ testAllocateFull : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testAllocateFull_t : types.
 
 (* closures.go *)
 
@@ -78,9 +63,6 @@ Definition adder: val :=
       "sum" <-[uint64T] ![uint64T] "sum" + "x";;
       ![uint64T] "sum"
       ).
-Theorem adder_t: ⊢ adder : (unitT -> AdderType).
-Proof. typecheck. Qed.
-Hint Resolve adder_t : types.
 
 Definition testClosureBasic: val :=
   rec: "testClosureBasic" <> :=
@@ -94,9 +76,6 @@ Definition testClosureBasic: val :=
     (if: ("pos" #0 = #45) && ("doub" #0 = #90)
     then #true
     else #false).
-Theorem testClosureBasic_t: ⊢ testClosureBasic : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testClosureBasic_t : types.
 
 (* comparisons.go *)
 
@@ -112,9 +91,6 @@ Definition testCompareAll: val :=
     (if: ![boolT] "nok"
     then #false
     else ![boolT] "ok").
-Theorem testCompareAll_t: ⊢ testCompareAll : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testCompareAll_t : types.
 
 Definition testCompareGT: val :=
   rec: "testCompareGT" <> :=
@@ -124,9 +100,6 @@ Definition testCompareGT: val :=
     "ok" <-[boolT] (![boolT] "ok") && (![uint64T] "y" > #4);;
     "ok" <-[boolT] (![boolT] "ok") && (![uint64T] "y" > ![uint64T] "x");;
     ![boolT] "ok".
-Theorem testCompareGT_t: ⊢ testCompareGT : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testCompareGT_t : types.
 
 Definition testCompareGE: val :=
   rec: "testCompareGE" <> :=
@@ -139,9 +112,6 @@ Definition testCompareGE: val :=
     (if: ![uint64T] "y" > #5
     then #false
     else ![boolT] "ok").
-Theorem testCompareGE_t: ⊢ testCompareGE : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testCompareGE_t : types.
 
 Definition testCompareLT: val :=
   rec: "testCompareLT" <> :=
@@ -151,9 +121,6 @@ Definition testCompareLT: val :=
     "ok" <-[boolT] (![boolT] "ok") && (![uint64T] "y" < #6);;
     "ok" <-[boolT] (![boolT] "ok") && (![uint64T] "x" < ![uint64T] "y");;
     ![boolT] "ok".
-Theorem testCompareLT_t: ⊢ testCompareLT : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testCompareLT_t : types.
 
 Definition testCompareLE: val :=
   rec: "testCompareLE" <> :=
@@ -166,9 +133,6 @@ Definition testCompareLE: val :=
     (if: ![uint64T] "y" < #5
     then #false
     else ![boolT] "ok").
-Theorem testCompareLE_t: ⊢ testCompareLE : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testCompareLE_t : types.
 
 (* conversions.go *)
 
@@ -176,24 +140,15 @@ Definition literalCast: val :=
   rec: "literalCast" <> :=
     let: "x" := #2 in
     "x" + #2.
-Theorem literalCast_t: ⊢ literalCast : (unitT -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve literalCast_t : types.
 
 Definition stringToByteSlice: val :=
   rec: "stringToByteSlice" "s" :=
     let: "p" := Data.stringToBytes "s" in
     "p".
-Theorem stringToByteSlice_t: ⊢ stringToByteSlice : (stringT -> slice.T byteT).
-Proof. typecheck. Qed.
-Hint Resolve stringToByteSlice_t : types.
 
 Definition byteSliceToString: val :=
   rec: "byteSliceToString" "p" :=
     Data.bytesToString "p".
-Theorem byteSliceToString_t: ⊢ byteSliceToString : (slice.T byteT -> stringT).
-Proof. typecheck. Qed.
-Hint Resolve byteSliceToString_t : types.
 
 (* tests *)
 Definition testByteSliceToString: val :=
@@ -203,9 +158,6 @@ Definition testByteSliceToString: val :=
     SliceSet byteT "x" #1 (#(U8 66));;
     SliceSet byteT "x" #2 (#(U8 67));;
     (byteSliceToString "x" = #(str"ABC")).
-Theorem testByteSliceToString_t: ⊢ testByteSliceToString : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testByteSliceToString_t : types.
 
 (* copy.go *)
 
@@ -216,9 +168,6 @@ Definition testCopySimple: val :=
     let: "y" := NewSlice byteT #10 in
     SliceCopy byteT "y" "x";;
     (SliceGet byteT "y" #3 = #(U8 1)).
-Theorem testCopySimple_t: ⊢ testCopySimple : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testCopySimple_t : types.
 
 Definition testCopyShorterDst: val :=
   rec: "testCopyShorterDst" <> :=
@@ -228,9 +177,6 @@ Definition testCopyShorterDst: val :=
     let: "y" := NewSlice byteT #10 in
     let: "n" := SliceCopy byteT "y" "x" in
     ("n" = #10) && (SliceGet byteT "y" #3 = #(U8 1)).
-Theorem testCopyShorterDst_t: ⊢ testCopyShorterDst : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testCopyShorterDst_t : types.
 
 Definition testCopyShorterSrc: val :=
   rec: "testCopyShorterSrc" <> :=
@@ -240,9 +186,6 @@ Definition testCopyShorterSrc: val :=
     SliceSet byteT "y" #12 (#(U8 2));;
     let: "n" := SliceCopy byteT "y" "x" in
     ("n" = #10) && (SliceGet byteT "y" #3 = #(U8 1)) && (SliceGet byteT "y" #12 = #(U8 2)).
-Theorem testCopyShorterSrc_t: ⊢ testCopyShorterSrc : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testCopyShorterSrc_t : types.
 
 (* encoding.go *)
 
@@ -256,9 +199,6 @@ Definition Enc__consume: val :=
     let: "b" := SliceTake (struct.loadF Enc "p" "e") "n" in
     struct.storeF Enc "p" "e" (SliceSkip byteT (struct.loadF Enc "p" "e") "n");;
     "b".
-Theorem Enc__consume_t: ⊢ Enc__consume : (struct.ptrT Enc -> uint64T -> slice.T byteT).
-Proof. typecheck. Qed.
-Hint Resolve Enc__consume_t : types.
 
 Definition Dec := struct.decl [
   "p" :: slice.T byteT
@@ -269,9 +209,6 @@ Definition Dec__consume: val :=
     let: "b" := SliceTake (struct.loadF Dec "p" "d") "n" in
     struct.storeF Dec "p" "d" (SliceSkip byteT (struct.loadF Dec "p" "d") "n");;
     "b".
-Theorem Dec__consume_t: ⊢ Dec__consume : (struct.ptrT Dec -> uint64T -> slice.T byteT).
-Proof. typecheck. Qed.
-Hint Resolve Dec__consume_t : types.
 
 Definition roundtripEncDec32: val :=
   rec: "roundtripEncDec32" "x" :=
@@ -284,9 +221,6 @@ Definition roundtripEncDec32: val :=
     ] in
     UInt32Put (Enc__consume "e" #4) "x";;
     UInt32Get (Dec__consume "d" #4).
-Theorem roundtripEncDec32_t: ⊢ roundtripEncDec32 : (uint32T -> uint32T).
-Proof. typecheck. Qed.
-Hint Resolve roundtripEncDec32_t : types.
 
 Definition roundtripEncDec64: val :=
   rec: "roundtripEncDec64" "x" :=
@@ -299,9 +233,6 @@ Definition roundtripEncDec64: val :=
     ] in
     UInt64Put (Enc__consume "e" #8) "x";;
     UInt64Get (Dec__consume "d" #8).
-Theorem roundtripEncDec64_t: ⊢ roundtripEncDec64 : (uint64T -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve roundtripEncDec64_t : types.
 
 (* tests *)
 Definition testEncDec32Simple: val :=
@@ -311,9 +242,6 @@ Definition testEncDec32Simple: val :=
     "ok" <-[boolT] (![boolT] "ok") && (roundtripEncDec32 (#(U32 1)) = #(U32 1));;
     "ok" <-[boolT] (![boolT] "ok") && (roundtripEncDec32 (#(U32 1231234)) = #(U32 1231234));;
     ![boolT] "ok".
-Theorem testEncDec32Simple_t: ⊢ testEncDec32Simple : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testEncDec32Simple_t : types.
 
 Definition failing_testEncDec32: val :=
   rec: "failing_testEncDec32" <> :=
@@ -325,9 +253,6 @@ Definition failing_testEncDec32: val :=
     "ok" <-[boolT] (![boolT] "ok") && (roundtripEncDec32 (#1 ≪ #0) = #1 ≪ #0);;
     "ok" <-[boolT] (![boolT] "ok") && (roundtripEncDec32 (#1 ≪ #32 - #1) = #1 ≪ #32 - #1);;
     ![boolT] "ok".
-Theorem failing_testEncDec32_t: ⊢ failing_testEncDec32 : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve failing_testEncDec32_t : types.
 
 Definition testEncDec64Simple: val :=
   rec: "testEncDec64Simple" <> :=
@@ -336,9 +261,6 @@ Definition testEncDec64Simple: val :=
     "ok" <-[boolT] (![boolT] "ok") && (roundtripEncDec64 #1 = #1);;
     "ok" <-[boolT] (![boolT] "ok") && (roundtripEncDec64 #1231234 = #1231234);;
     ![boolT] "ok".
-Theorem testEncDec64Simple_t: ⊢ testEncDec64Simple : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testEncDec64Simple_t : types.
 
 Definition testEncDec64: val :=
   rec: "testEncDec64" <> :=
@@ -352,9 +274,6 @@ Definition testEncDec64: val :=
     "ok" <-[boolT] (![boolT] "ok") && (roundtripEncDec64 (#1 ≪ #0) = #1 ≪ #0);;
     "ok" <-[boolT] (![boolT] "ok") && (roundtripEncDec64 (#1 ≪ #64 - #1) = #1 ≪ #64 - #1);;
     ![boolT] "ok".
-Theorem testEncDec64_t: ⊢ testEncDec64 : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testEncDec64_t : types.
 
 (* function_ordering.go *)
 
@@ -373,18 +292,12 @@ Definition Editor__AdvanceReturn: val :=
     struct.storeF Editor "next_val" "e" "next";;
     struct.storeF Editor "s" "e" (SliceSkip uint64T (struct.loadF Editor "s" "e") #1);;
     ![uint64T] "tmp".
-Theorem Editor__AdvanceReturn_t: ⊢ Editor__AdvanceReturn : (struct.ptrT Editor -> uint64T -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve Editor__AdvanceReturn_t : types.
 
 (* we call this function with side-effectful function calls as arguments,
    its implementation is unimportant *)
 Definition addFour64: val :=
   rec: "addFour64" "a" "b" "c" "d" :=
     "a" + "b" + "c" + "d".
-Theorem addFour64_t: ⊢ addFour64 : (uint64T -> uint64T -> uint64T -> uint64T -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve addFour64_t : types.
 
 Definition Pair := struct.decl [
   "x" :: uint64T;
@@ -432,9 +345,6 @@ Definition failing_testFunctionOrdering: val :=
                 (if: SliceGet uint64T (![slice.T uint64T] "arr") #4 ≠ #105
                 then #false
                 else (struct.get Pair "x" "p" + struct.get Pair "x" "q" = #109)))))))).
-Theorem failing_testFunctionOrdering_t: ⊢ failing_testFunctionOrdering : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve failing_testFunctionOrdering_t : types.
 
 (* int_conversions.go *)
 
@@ -446,17 +356,11 @@ Definition testU64ToU32: val :=
     "ok" <-[boolT] (![boolT] "ok") && (to_u32 "x" = "y");;
     "ok" <-[boolT] (![boolT] "ok") && (to_u64 "y" = "x");;
     ![boolT] "ok".
-Theorem testU64ToU32_t: ⊢ testU64ToU32 : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testU64ToU32_t : types.
 
 Definition testU32Len: val :=
   rec: "testU32Len" <> :=
     let: "s" := NewSlice byteT #100 in
     (to_u32 (slice.len "s") = #(U32 100)).
-Theorem testU32Len_t: ⊢ testU32Len : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testU32Len_t : types.
 
 Definition Uint32: ty := uint32T.
 
@@ -465,9 +369,6 @@ Definition failing_testU32NewtypeLen: val :=
   rec: "failing_testU32NewtypeLen" <> :=
     let: "s" := NewSlice byteT #20 in
     (slice.len "s" = #(U32 20)).
-Theorem failing_testU32NewtypeLen_t: ⊢ failing_testU32NewtypeLen : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve failing_testU32NewtypeLen_t : types.
 
 (* interfaces.go *)
 
@@ -479,23 +380,14 @@ Definition geometryInterface := struct.decl [
 Definition measureArea: val :=
   rec: "measureArea" "t" :=
     struct.get geometryInterface "Square" "t".
-Theorem measureArea_t: ⊢ measureArea : (geometryInterface -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve measureArea_t : types.
 
 Definition measureVolumePlusNM: val :=
   rec: "measureVolumePlusNM" "t" "n" "m" :=
     struct.get geometryInterface "Volume" "t" + "n" + "m".
-Theorem measureVolumePlusNM_t: ⊢ measureVolumePlusNM : (geometryInterface -> uint64T -> uint64T -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve measureVolumePlusNM_t : types.
 
 Definition measureVolume: val :=
   rec: "measureVolume" "t" :=
     struct.get geometryInterface "Volume" "t".
-Theorem measureVolume_t: ⊢ measureVolume : (geometryInterface -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve measureVolume_t : types.
 
 Definition SquareStruct := struct.decl [
   "Side" :: uint64T
@@ -504,16 +396,10 @@ Definition SquareStruct := struct.decl [
 Definition SquareStruct__Square: val :=
   rec: "SquareStruct__Square" "t" :=
     struct.get SquareStruct "Side" "t" * struct.get SquareStruct "Side" "t".
-Theorem SquareStruct__Square_t: ⊢ SquareStruct__Square : (struct.t SquareStruct -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve SquareStruct__Square_t : types.
 
 Definition SquareStruct__Volume: val :=
   rec: "SquareStruct__Volume" "t" :=
     struct.get SquareStruct "Side" "t" * struct.get SquareStruct "Side" "t" * struct.get SquareStruct "Side" "t".
-Theorem SquareStruct__Volume_t: ⊢ SquareStruct__Volume : (struct.t SquareStruct -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve SquareStruct__Volume_t : types.
 
 Definition SquareStruct__to__geometryInterface: val :=
   rec: "SquareStruct_to_geometryInterface" "t" :=
@@ -528,9 +414,6 @@ Definition testBasicInterface: val :=
       "Side" ::= #2
     ] in
     (measureArea (SquareStruct__to__geometryInterface "s") = #4).
-Theorem testBasicInterface_t: ⊢ testBasicInterface : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testBasicInterface_t : types.
 
 Definition testAssignInterface: val :=
   rec: "testAssignInterface" <> :=
@@ -539,9 +422,6 @@ Definition testAssignInterface: val :=
     ] in
     let: "area" := measureArea (SquareStruct__to__geometryInterface "s") in
     ("area" = #9).
-Theorem testAssignInterface_t: ⊢ testAssignInterface : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testAssignInterface_t : types.
 
 Definition testMultipleInterface: val :=
   rec: "testMultipleInterface" <> :=
@@ -551,9 +431,6 @@ Definition testMultipleInterface: val :=
     let: "square1" := measureArea (SquareStruct__to__geometryInterface "s") in
     let: "square2" := measureArea (SquareStruct__to__geometryInterface "s") in
     ("square1" = "square2").
-Theorem testMultipleInterface_t: ⊢ testMultipleInterface : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testMultipleInterface_t : types.
 
 Definition testBinaryExprInterface: val :=
   rec: "testBinaryExprInterface" <> :=
@@ -563,9 +440,6 @@ Definition testBinaryExprInterface: val :=
     let: "square1" := measureArea (SquareStruct__to__geometryInterface "s") in
     let: "square2" := measureVolume (SquareStruct__to__geometryInterface "s") in
     ("square1" = measureArea (SquareStruct__to__geometryInterface "s")) && ("square2" = measureVolume (SquareStruct__to__geometryInterface "s")).
-Theorem testBinaryExprInterface_t: ⊢ testBinaryExprInterface : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testBinaryExprInterface_t : types.
 
 Definition testIfStmtInterface: val :=
   rec: "testIfStmtInterface" <> :=
@@ -575,9 +449,6 @@ Definition testIfStmtInterface: val :=
     (if: (measureArea (SquareStruct__to__geometryInterface "s") = #9)
     then #true
     else #false).
-Theorem testIfStmtInterface_t: ⊢ testIfStmtInterface : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testIfStmtInterface_t : types.
 
 (* interfaces_failing.go *)
 
@@ -591,9 +462,6 @@ Definition testsUseLocks: val :=
     lock.acquire "m";;
     lock.release "m";;
     #true.
-Theorem testsUseLocks_t: ⊢ testsUseLocks : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testsUseLocks_t : types.
 
 (* loops.go *)
 
@@ -613,13 +481,10 @@ Definition standardForLoop: val :=
       else Break));;
     let: "sum" := ![uint64T] "sumPtr" in
     "sum".
-Theorem standardForLoop_t: ⊢ standardForLoop : (slice.T uint64T -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve standardForLoop_t : types.
 
 (* based off diskAppendWait loop pattern in logging2 *)
 Definition LoopStruct := struct.decl [
-  "loopNext" :: refT uint64T
+  "loopNext" :: ptrT
 ].
 
 Definition LoopStruct__forLoopWait: val :=
@@ -633,9 +498,6 @@ Definition LoopStruct__forLoopWait: val :=
         struct.get LoopStruct "loopNext" "ls" <-[uint64T] ![uint64T] (struct.get LoopStruct "loopNext" "ls") + #1;;
         Continue));;
     #().
-Theorem LoopStruct__forLoopWait_t: ⊢ LoopStruct__forLoopWait : (struct.t LoopStruct -> uint64T -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve LoopStruct__forLoopWait_t : types.
 
 (* tests *)
 Definition testStandardForLoop: val :=
@@ -646,9 +508,6 @@ Definition testStandardForLoop: val :=
     SliceSet uint64T (![slice.T uint64T] "arr") #2 (SliceGet uint64T (![slice.T uint64T] "arr") #2 + #5);;
     SliceSet uint64T (![slice.T uint64T] "arr") #3 (SliceGet uint64T (![slice.T uint64T] "arr") #3 + #7);;
     (standardForLoop (![slice.T uint64T] "arr") = #16).
-Theorem testStandardForLoop_t: ⊢ testStandardForLoop : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testStandardForLoop_t : types.
 
 Definition testForLoopWait: val :=
   rec: "testForLoopWait" <> :=
@@ -657,9 +516,6 @@ Definition testForLoopWait: val :=
     ] in
     LoopStruct__forLoopWait "ls" #3;;
     (![uint64T] (struct.get LoopStruct "loopNext" "ls") = #4).
-Theorem testForLoopWait_t: ⊢ testForLoopWait : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testForLoopWait_t : types.
 
 Definition testBreakFromLoopWithContinue: val :=
   rec: "testBreakFromLoopWithContinue" <> :=
@@ -672,9 +528,6 @@ Definition testBreakFromLoopWithContinue: val :=
         Break
       else Continue));;
     (![uint64T] "i" = #1).
-Theorem testBreakFromLoopWithContinue_t: ⊢ testBreakFromLoopWithContinue : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testBreakFromLoopWithContinue_t : types.
 
 Definition testBreakFromLoopNoContinue: val :=
   rec: "testBreakFromLoopNoContinue" <> :=
@@ -689,9 +542,6 @@ Definition testBreakFromLoopNoContinue: val :=
         "i" <-[uint64T] ![uint64T] "i" + #2;;
         Continue));;
     (![uint64T] "i" = #1).
-Theorem testBreakFromLoopNoContinue_t: ⊢ testBreakFromLoopNoContinue : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testBreakFromLoopNoContinue_t : types.
 
 Definition testBreakFromLoopNoContinueDouble: val :=
   rec: "testBreakFromLoopNoContinueDouble" <> :=
@@ -707,9 +557,6 @@ Definition testBreakFromLoopNoContinueDouble: val :=
         "i" <-[uint64T] ![uint64T] "i" + #2;;
         Continue));;
     (![uint64T] "i" = #4).
-Theorem testBreakFromLoopNoContinueDouble_t: ⊢ testBreakFromLoopNoContinueDouble : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testBreakFromLoopNoContinueDouble_t : types.
 
 Definition testBreakFromLoopForOnly: val :=
   rec: "testBreakFromLoopForOnly" <> :=
@@ -719,9 +566,6 @@ Definition testBreakFromLoopForOnly: val :=
       "i" <-[uint64T] ![uint64T] "i" + #2;;
       Continue);;
     (![uint64T] "i" = #4).
-Theorem testBreakFromLoopForOnly_t: ⊢ testBreakFromLoopForOnly : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testBreakFromLoopForOnly_t : types.
 
 Definition testBreakFromLoopAssignAndContinue: val :=
   rec: "testBreakFromLoopAssignAndContinue" <> :=
@@ -736,9 +580,6 @@ Definition testBreakFromLoopAssignAndContinue: val :=
         "i" <-[uint64T] ![uint64T] "i" + #2;;
         Continue));;
     (![uint64T] "i" = #1).
-Theorem testBreakFromLoopAssignAndContinue_t: ⊢ testBreakFromLoopAssignAndContinue : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testBreakFromLoopAssignAndContinue_t : types.
 
 Definition testNestedLoops: val :=
   rec: "testNestedLoops" <> :=
@@ -758,9 +599,6 @@ Definition testNestedLoops: val :=
       "ok2" <-[boolT] (![uint64T] "i" = #1);;
       Break);;
     (![boolT] "ok1") && (![boolT] "ok2").
-Theorem testNestedLoops_t: ⊢ testNestedLoops : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testNestedLoops_t : types.
 
 Definition testNestedGoStyleLoops: val :=
   rec: "testNestedGoStyleLoops" <> :=
@@ -775,9 +613,6 @@ Definition testNestedGoStyleLoops: val :=
       "ok" <-[boolT] (![uint64T] "i" = #9);;
       Continue);;
     ![boolT] "ok".
-Theorem testNestedGoStyleLoops_t: ⊢ testNestedGoStyleLoops : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testNestedGoStyleLoops_t : types.
 
 Definition testNestedGoStyleLoopsNoComparison: val :=
   rec: "testNestedGoStyleLoopsNoComparison" <> :=
@@ -792,9 +627,6 @@ Definition testNestedGoStyleLoopsNoComparison: val :=
       "ok" <-[boolT] (![uint64T] "i" = #9);;
       Continue);;
     ![boolT] "ok".
-Theorem testNestedGoStyleLoopsNoComparison_t: ⊢ testNestedGoStyleLoopsNoComparison : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testNestedGoStyleLoopsNoComparison_t : types.
 
 (* maps.go *)
 
@@ -804,9 +636,6 @@ Definition IterateMapKeys: val :=
     MapIter "m" (λ: "k" <>,
       "sum" <-[uint64T] ![uint64T] "sum" + "k");;
     ![uint64T] "sum".
-Theorem IterateMapKeys_t: ⊢ IterateMapKeys : (mapT uint64T -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve IterateMapKeys_t : types.
 
 Definition IterateMapValues: val :=
   rec: "IterateMapValues" "m" :=
@@ -814,9 +643,6 @@ Definition IterateMapValues: val :=
     MapIter "m" (λ: <> "v",
       "sum" <-[uint64T] ![uint64T] "sum" + "v");;
     ![uint64T] "sum".
-Theorem IterateMapValues_t: ⊢ IterateMapValues : (mapT uint64T -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve IterateMapValues_t : types.
 
 Definition testIterateMap: val :=
   rec: "testIterateMap" <> :=
@@ -828,9 +654,6 @@ Definition testIterateMap: val :=
     "ok" <-[boolT] (![boolT] "ok") && (IterateMapKeys "m" = #4);;
     "ok" <-[boolT] (![boolT] "ok") && (IterateMapValues "m" = #7);;
     ![boolT] "ok".
-Theorem testIterateMap_t: ⊢ testIterateMap : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testIterateMap_t : types.
 
 Definition testMapSize: val :=
   rec: "testMapSize" <> :=
@@ -842,64 +665,40 @@ Definition testMapSize: val :=
     MapInsert "m" #3 #4;;
     "ok" <-[boolT] (![boolT] "ok") && (MapLen "m" = #3);;
     ![boolT] "ok".
-Theorem testMapSize_t: ⊢ testMapSize : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testMapSize_t : types.
 
 (* multiple_return.go *)
 
 Definition returnTwo: val :=
   rec: "returnTwo" <> :=
     (#2, #3).
-Theorem returnTwo_t: ⊢ returnTwo : (unitT -> (uint64T * uint64T)).
-Proof. typecheck. Qed.
-Hint Resolve returnTwo_t : types.
 
 Definition testReturnTwo: val :=
   rec: "testReturnTwo" <> :=
     let: ("x", "y") := returnTwo #() in
     ("x" = #2) && ("y" = #3).
-Theorem testReturnTwo_t: ⊢ testReturnTwo : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testReturnTwo_t : types.
 
 Definition testAnonymousBinding: val :=
   rec: "testAnonymousBinding" <> :=
     let: (<>, "y") := returnTwo #() in
     ("y" = #3).
-Theorem testAnonymousBinding_t: ⊢ testAnonymousBinding : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testAnonymousBinding_t : types.
 
 Definition returnThree: val :=
   rec: "returnThree" <> :=
     (#2, #true, #(U32 1)).
-Theorem returnThree_t: ⊢ returnThree : (unitT -> (uint64T * boolT * uint32T)).
-Proof. typecheck. Qed.
-Hint Resolve returnThree_t : types.
 
 Definition testReturnThree: val :=
   rec: "testReturnThree" <> :=
     let: (("x", "y"), "z") := returnThree #() in
     ("x" = #2) && ("y" = #true) && ("z" = #(U32 1)).
-Theorem testReturnThree_t: ⊢ testReturnThree : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testReturnThree_t : types.
 
 Definition returnFour: val :=
   rec: "returnFour" <> :=
     (#2, #true, #(U32 1), #7).
-Theorem returnFour_t: ⊢ returnFour : (unitT -> (uint64T * boolT * uint32T * uint64T)).
-Proof. typecheck. Qed.
-Hint Resolve returnFour_t : types.
 
 Definition testReturnFour: val :=
   rec: "testReturnFour" <> :=
     let: ((("x", "y"), "z"), "w") := returnFour #() in
     ("x" = #2) && ("y" = #true) && ("z" = #(U32 1)) && ("w" = #7).
-Theorem testReturnFour_t: ⊢ testReturnFour : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testReturnFour_t : types.
 
 (* nil.go *)
 
@@ -907,42 +706,27 @@ Definition failing_testCompareSliceToNil: val :=
   rec: "failing_testCompareSliceToNil" <> :=
     let: "s" := NewSlice byteT #0 in
     "s" ≠ slice.nil.
-Theorem failing_testCompareSliceToNil_t: ⊢ failing_testCompareSliceToNil : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve failing_testCompareSliceToNil_t : types.
 
 Definition testComparePointerToNil: val :=
   rec: "testComparePointerToNil" <> :=
     let: "s" := ref (zero_val uint64T) in
     "s" ≠ #null.
-Theorem testComparePointerToNil_t: ⊢ testComparePointerToNil : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testComparePointerToNil_t : types.
 
 Definition testCompareNilToNil: val :=
   rec: "testCompareNilToNil" <> :=
-    let: "s" := ref (zero_val (refT uint64T)) in
-    (![refT uint64T] "s" = #null).
-Theorem testCompareNilToNil_t: ⊢ testCompareNilToNil : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testCompareNilToNil_t : types.
+    let: "s" := ref (zero_val ptrT) in
+    (![ptrT] "s" = #null).
 
 Definition testComparePointerWrappedToNil: val :=
   rec: "testComparePointerWrappedToNil" <> :=
     let: "s" := ref (zero_val (slice.T byteT)) in
     "s" <-[slice.T byteT] NewSlice byteT #1;;
     ![slice.T byteT] "s" ≠ slice.nil.
-Theorem testComparePointerWrappedToNil_t: ⊢ testComparePointerWrappedToNil : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testComparePointerWrappedToNil_t : types.
 
 Definition testComparePointerWrappedDefaultToNil: val :=
   rec: "testComparePointerWrappedDefaultToNil" <> :=
     let: "s" := ref (zero_val (slice.T byteT)) in
     (![slice.T byteT] "s" = slice.nil).
-Theorem testComparePointerWrappedDefaultToNil_t: ⊢ testComparePointerWrappedDefaultToNil : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testComparePointerWrappedDefaultToNil_t : types.
 
 (* operations.go *)
 
@@ -955,9 +739,6 @@ Definition reverseAssignOps64: val :=
     "y" <-[uint64T] ![uint64T] "y" + #1;;
     "y" <-[uint64T] ![uint64T] "y" - #1;;
     ![uint64T] "y".
-Theorem reverseAssignOps64_t: ⊢ reverseAssignOps64 : (uint64T -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve reverseAssignOps64_t : types.
 
 Definition reverseAssignOps32: val :=
   rec: "reverseAssignOps32" "x" :=
@@ -967,23 +748,14 @@ Definition reverseAssignOps32: val :=
     "y" <-[uint32T] ![uint32T] "y" + #1;;
     "y" <-[uint32T] ![uint32T] "y" - #1;;
     ![uint32T] "y".
-Theorem reverseAssignOps32_t: ⊢ reverseAssignOps32 : (uint32T -> uint32T).
-Proof. typecheck. Qed.
-Hint Resolve reverseAssignOps32_t : types.
 
 Definition add64Equals: val :=
   rec: "add64Equals" "x" "y" "z" :=
     ("x" + "y" = "z").
-Theorem add64Equals_t: ⊢ add64Equals : (uint64T -> uint64T -> uint64T -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve add64Equals_t : types.
 
 Definition sub64Equals: val :=
   rec: "sub64Equals" "x" "y" "z" :=
     ("x" - "y" = "z").
-Theorem sub64Equals_t: ⊢ sub64Equals : (uint64T -> uint64T -> uint64T -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve sub64Equals_t : types.
 
 (* tests *)
 Definition testReverseAssignOps64: val :=
@@ -1001,9 +773,6 @@ Definition testReverseAssignOps64: val :=
     "ok" <-[boolT] (![boolT] "ok") && (reverseAssignOps64 (#1 ≪ #0) = #0);;
     "ok" <-[boolT] (![boolT] "ok") && (reverseAssignOps64 (#1 ≪ #64 - #1) = #0);;
     ![boolT] "ok".
-Theorem testReverseAssignOps64_t: ⊢ testReverseAssignOps64 : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testReverseAssignOps64_t : types.
 
 Definition failing_testReverseAssignOps32: val :=
   rec: "failing_testReverseAssignOps32" <> :=
@@ -1018,9 +787,6 @@ Definition failing_testReverseAssignOps32: val :=
     "ok" <-[boolT] (![boolT] "ok") && (reverseAssignOps32 (#1 ≪ #0) = #(U32 0));;
     "ok" <-[boolT] (![boolT] "ok") && (reverseAssignOps32 (#1 ≪ #32 - #1) = #(U32 0));;
     ![boolT] "ok".
-Theorem failing_testReverseAssignOps32_t: ⊢ failing_testReverseAssignOps32 : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve failing_testReverseAssignOps32_t : types.
 
 Definition testAdd64Equals: val :=
   rec: "testAdd64Equals" <> :=
@@ -1028,9 +794,6 @@ Definition testAdd64Equals: val :=
     "ok" <-[boolT] (![boolT] "ok") && (add64Equals #2 #3 #5);;
     "ok" <-[boolT] (![boolT] "ok") && (add64Equals (#1 ≪ #64 - #1) #1 #0);;
     ![boolT] "ok".
-Theorem testAdd64Equals_t: ⊢ testAdd64Equals : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testAdd64Equals_t : types.
 
 Definition testSub64Equals: val :=
   rec: "testSub64Equals" <> :=
@@ -1039,9 +802,6 @@ Definition testSub64Equals: val :=
     "ok" <-[boolT] (![boolT] "ok") && (sub64Equals (#1 ≪ #64 - #1) (#1 ≪ #63) (#1 ≪ #63 - #1));;
     "ok" <-[boolT] (![boolT] "ok") && (sub64Equals #2 #8 (#1 ≪ #64 - #6));;
     ![boolT] "ok".
-Theorem testSub64Equals_t: ⊢ testSub64Equals : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testSub64Equals_t : types.
 
 Definition testDivisionPrecedence: val :=
   rec: "testDivisionPrecedence" <> :=
@@ -1049,18 +809,12 @@ Definition testDivisionPrecedence: val :=
     let: "hdrmeta" := #8 in
     let: "hdraddrs" := ("blockSize" - "hdrmeta") `quot` #8 in
     ("hdraddrs" = #511).
-Theorem testDivisionPrecedence_t: ⊢ testDivisionPrecedence : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testDivisionPrecedence_t : types.
 
 Definition testModPrecedence: val :=
   rec: "testModPrecedence" <> :=
     let: "x1" := #513 + #12 `rem` #8 in
     let: "x2" := (#513 + #12) `rem` #8 in
     ("x1" = #517) && ("x2" = #5).
-Theorem testModPrecedence_t: ⊢ testModPrecedence : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testModPrecedence_t : types.
 
 Definition testBitwiseOpsPrecedence: val :=
   rec: "testBitwiseOpsPrecedence" <> :=
@@ -1072,9 +826,6 @@ Definition testBitwiseOpsPrecedence: val :=
     "ok" <-[boolT] (![boolT] "ok") && ((#468 `and` #1191) `or` #333 = #461);;
     "ok" <-[boolT] (![boolT] "ok") && (#222 `or` (#327 `and` #421) ≠ #389);;
     ![boolT] "ok".
-Theorem testBitwiseOpsPrecedence_t: ⊢ testBitwiseOpsPrecedence : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testBitwiseOpsPrecedence_t : types.
 
 Definition testArithmeticShifts: val :=
   rec: "testArithmeticShifts" <> :=
@@ -1085,9 +836,6 @@ Definition testArithmeticShifts: val :=
     "ok" <-[boolT] (![boolT] "ok") && (#672 ≫ #12 = #0);;
     "ok" <-[boolT] (![boolT] "ok") && ((#672 ≫ #4) ≪ #4 = #672);;
     ![boolT] "ok".
-Theorem testArithmeticShifts_t: ⊢ testArithmeticShifts : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testArithmeticShifts_t : types.
 
 (* precedence.go *)
 
@@ -1096,9 +844,6 @@ Definition testOrCompareSimple: val :=
     (if: (#3 > #4) || (#4 > #3)
     then #true
     else #false).
-Theorem testOrCompareSimple_t: ⊢ testOrCompareSimple : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testOrCompareSimple_t : types.
 
 Definition testOrCompare: val :=
   rec: "testOrCompare" <> :=
@@ -1110,9 +855,6 @@ Definition testOrCompare: val :=
     then "ok" <-[boolT] #false
     else #());;
     ![boolT] "ok".
-Theorem testOrCompare_t: ⊢ testOrCompare : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testOrCompare_t : types.
 
 Definition testAndCompare: val :=
   rec: "testAndCompare" <> :=
@@ -1124,16 +866,10 @@ Definition testAndCompare: val :=
     then #()
     else "ok" <-[boolT] #false);;
     ![boolT] "ok".
-Theorem testAndCompare_t: ⊢ testAndCompare : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testAndCompare_t : types.
 
 Definition testShiftMod: val :=
   rec: "testShiftMod" <> :=
     (#20 ≫ (#8 `rem` #4) = #20).
-Theorem testShiftMod_t: ⊢ testShiftMod : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testShiftMod_t : types.
 
 (* prims.go *)
 
@@ -1144,9 +880,6 @@ Definition testLinearize: val :=
     Linearize;;
     lock.release "m";;
     #true.
-Theorem testLinearize_t: ⊢ testLinearize : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testLinearize_t : types.
 
 (* shortcircuiting.go *)
 
@@ -1162,17 +895,11 @@ Definition CheckTrue: val :=
   rec: "CheckTrue" "b" :=
     struct.storeF BoolTest "tc" "b" (struct.loadF BoolTest "tc" "b" + #1);;
     struct.loadF BoolTest "t" "b".
-Theorem CheckTrue_t: ⊢ CheckTrue : (struct.ptrT BoolTest -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve CheckTrue_t : types.
 
 Definition CheckFalse: val :=
   rec: "CheckFalse" "b" :=
     struct.storeF BoolTest "fc" "b" (struct.loadF BoolTest "fc" "b" + #1);;
     struct.loadF BoolTest "f" "b".
-Theorem CheckFalse_t: ⊢ CheckFalse : (struct.ptrT BoolTest -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve CheckFalse_t : types.
 
 (* tests *)
 Definition testShortcircuitAndTF: val :=
@@ -1186,9 +913,6 @@ Definition testShortcircuitAndTF: val :=
     (if: (CheckTrue "b") && (CheckFalse "b")
     then #false
     else (struct.loadF BoolTest "tc" "b" = #1) && (struct.loadF BoolTest "fc" "b" = #1)).
-Theorem testShortcircuitAndTF_t: ⊢ testShortcircuitAndTF : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testShortcircuitAndTF_t : types.
 
 Definition testShortcircuitAndFT: val :=
   rec: "testShortcircuitAndFT" <> :=
@@ -1201,9 +925,6 @@ Definition testShortcircuitAndFT: val :=
     (if: (CheckFalse "b") && (CheckTrue "b")
     then #false
     else (struct.loadF BoolTest "tc" "b" = #0) && (struct.loadF BoolTest "fc" "b" = #1)).
-Theorem testShortcircuitAndFT_t: ⊢ testShortcircuitAndFT : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testShortcircuitAndFT_t : types.
 
 Definition testShortcircuitOrTF: val :=
   rec: "testShortcircuitOrTF" <> :=
@@ -1216,9 +937,6 @@ Definition testShortcircuitOrTF: val :=
     (if: (CheckTrue "b") || (CheckFalse "b")
     then (struct.loadF BoolTest "tc" "b" = #1) && (struct.loadF BoolTest "fc" "b" = #0)
     else #false).
-Theorem testShortcircuitOrTF_t: ⊢ testShortcircuitOrTF : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testShortcircuitOrTF_t : types.
 
 Definition testShortcircuitOrFT: val :=
   rec: "testShortcircuitOrFT" <> :=
@@ -1231,9 +949,6 @@ Definition testShortcircuitOrFT: val :=
     (if: (CheckFalse "b") || (CheckTrue "b")
     then (struct.loadF BoolTest "tc" "b" = #1) && (struct.loadF BoolTest "fc" "b" = #1)
     else #false).
-Theorem testShortcircuitOrFT_t: ⊢ testShortcircuitOrFT : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testShortcircuitOrFT_t : types.
 
 (* slices.go *)
 
@@ -1250,9 +965,6 @@ Definition ArrayEditor__Advance: val :=
     struct.storeF ArrayEditor "next_val" "ae" "next";;
     struct.storeF ArrayEditor "s" "ae" (SliceSkip uint64T (struct.loadF ArrayEditor "s" "ae") #1);;
     #().
-Theorem ArrayEditor__Advance_t: ⊢ ArrayEditor__Advance : (struct.ptrT ArrayEditor -> slice.T uint64T -> uint64T -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve ArrayEditor__Advance_t : types.
 
 (* tests *)
 Definition testSliceOps: val :=
@@ -1275,9 +987,6 @@ Definition testSliceOps: val :=
     "ok" <-[boolT] (![boolT] "ok") && (slice.len "v3" = #3);;
     "ok" <-[boolT] (![boolT] "ok") && (![uint64T] "v4" = #10);;
     ![boolT] "ok".
-Theorem testSliceOps_t: ⊢ testSliceOps : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testSliceOps_t : types.
 
 Definition testOverwriteArray: val :=
   rec: "testOverwriteArray" <> :=
@@ -1300,9 +1009,6 @@ Definition testOverwriteArray: val :=
     (if: SliceGet uint64T (![slice.T uint64T] "arr") #0 + SliceGet uint64T (![slice.T uint64T] "arr") #1 + SliceGet uint64T (![slice.T uint64T] "arr") #2 + SliceGet uint64T (![slice.T uint64T] "arr") #3 ≥ #100
     then #false
     else (SliceGet uint64T (![slice.T uint64T] "arr") #3 = #4) && (SliceGet uint64T (![slice.T uint64T] "arr") #0 = #4)).
-Theorem testOverwriteArray_t: ⊢ testOverwriteArray : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testOverwriteArray_t : types.
 
 (* strings.go *)
 
@@ -1310,16 +1016,10 @@ Hint Resolve testOverwriteArray_t : types.
 Definition stringAppend: val :=
   rec: "stringAppend" "s" "x" :=
     "s" + uint64_to_string "x".
-Theorem stringAppend_t: ⊢ stringAppend : (stringT -> uint64T -> stringT).
-Proof. typecheck. Qed.
-Hint Resolve stringAppend_t : types.
 
 Definition stringLength: val :=
   rec: "stringLength" "s" :=
     strLen "s".
-Theorem stringLength_t: ⊢ stringLength : (stringT -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve stringLength_t : types.
 
 (* tests *)
 Definition failing_testStringAppend: val :=
@@ -1328,9 +1028,6 @@ Definition failing_testStringAppend: val :=
     let: "s" := ref_to stringT #(str"123") in
     let: "y" := ref_to stringT (stringAppend (![stringT] "s") #45) in
     (![boolT] "ok") && (![stringT] "y" = #(str"12345")).
-Theorem failing_testStringAppend_t: ⊢ failing_testStringAppend : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve failing_testStringAppend_t : types.
 
 Definition failing_testStringLength: val :=
   rec: "failing_testStringLength" <> :=
@@ -1341,9 +1038,6 @@ Definition failing_testStringLength: val :=
     "ok" <-[boolT] (![boolT] "ok") && (strLen (![stringT] "s") = #1);;
     "s" <-[stringT] stringAppend (![stringT] "s") #23;;
     (![boolT] "ok") && (strLen (![stringT] "s") = #3).
-Theorem failing_testStringLength_t: ⊢ failing_testStringLength : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve failing_testStringLength_t : types.
 
 (* struct_pointers.go *)
 
@@ -1363,17 +1057,11 @@ Definition Bar__mutate: val :=
     struct.storeF Bar "a" "bar" #2;;
     struct.storeF Bar "b" "bar" #3;;
     #().
-Theorem Bar__mutate_t: ⊢ Bar__mutate : (struct.ptrT Bar -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Bar__mutate_t : types.
 
 Definition Foo__mutateBar: val :=
   rec: "Foo__mutateBar" "foo" :=
     Bar__mutate (struct.loadF Foo "bar" "foo");;
     #().
-Theorem Foo__mutateBar_t: ⊢ Foo__mutateBar : (struct.ptrT Foo -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Foo__mutateBar_t : types.
 
 Definition failing_testFooBarMutation: val :=
   rec: "failing_testFooBarMutation" <> :=
@@ -1385,9 +1073,6 @@ Definition failing_testFooBarMutation: val :=
     ] in
     Foo__mutateBar "x";;
     (struct.get Bar "a" (struct.get Foo "bar" "x") = #2).
-Theorem failing_testFooBarMutation_t: ⊢ failing_testFooBarMutation : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve failing_testFooBarMutation_t : types.
 
 (* structs.go *)
 
@@ -1412,46 +1097,28 @@ Definition NewS: val :=
       ];
       "c" ::= #true
     ].
-Theorem NewS_t: ⊢ NewS : (unitT -> struct.ptrT S).
-Proof. typecheck. Qed.
-Hint Resolve NewS_t : types.
 
 Definition S__readA: val :=
   rec: "S__readA" "s" :=
     struct.loadF S "a" "s".
-Theorem S__readA_t: ⊢ S__readA : (struct.ptrT S -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve S__readA_t : types.
 
 Definition S__readB: val :=
   rec: "S__readB" "s" :=
     struct.loadF S "b" "s".
-Theorem S__readB_t: ⊢ S__readB : (struct.ptrT S -> struct.t TwoInts).
-Proof. typecheck. Qed.
-Hint Resolve S__readB_t : types.
 
 Definition S__readBVal: val :=
   rec: "S__readBVal" "s" :=
     struct.get S "b" "s".
-Theorem S__readBVal_t: ⊢ S__readBVal : (struct.t S -> struct.t TwoInts).
-Proof. typecheck. Qed.
-Hint Resolve S__readBVal_t : types.
 
 Definition S__updateBValX: val :=
   rec: "S__updateBValX" "s" "i" :=
     struct.storeF TwoInts "x" (struct.fieldRef S "b" "s") "i";;
     #().
-Theorem S__updateBValX_t: ⊢ S__updateBValX : (struct.ptrT S -> uint64T -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve S__updateBValX_t : types.
 
 Definition S__negateC: val :=
   rec: "S__negateC" "s" :=
     struct.storeF S "c" "s" (~ (struct.loadF S "c" "s"));;
     #().
-Theorem S__negateC_t: ⊢ S__negateC : (struct.ptrT S -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve S__negateC_t : types.
 
 Definition failing_testStructUpdates: val :=
   rec: "failing_testStructUpdates" <> :=
@@ -1465,42 +1132,36 @@ Definition failing_testStructUpdates: val :=
     struct.storeF TwoInts "x" "b1" #3;;
     let: "b2" := ref_to (struct.t TwoInts) (S__readB "ns") in
     "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (![struct.t TwoInts] "b2") = #1);;
-    let: "b3" := ref_to (refT (struct.t TwoInts)) (struct.fieldRef S "b" "ns") in
-    "ok" <-[boolT] (![boolT] "ok") && (struct.loadF TwoInts "x" (![refT (struct.t TwoInts)] "b3") = #1);;
+    let: "b3" := ref_to ptrT (struct.fieldRef S "b" "ns") in
+    "ok" <-[boolT] (![boolT] "ok") && (struct.loadF TwoInts "x" (![ptrT] "b3") = #1);;
     S__updateBValX "ns" #4;;
     "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (S__readBVal "ns") = #4);;
     ![boolT] "ok".
-Theorem failing_testStructUpdates_t: ⊢ failing_testStructUpdates : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve failing_testStructUpdates_t : types.
 
 Definition testNestedStructUpdates: val :=
   rec: "testNestedStructUpdates" <> :=
     let: "ok" := ref_to boolT #true in
-    let: "ns" := ref_to (refT (struct.t S)) (NewS #()) in
-    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![refT (struct.t S)] "ns")) #5;;
-    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.loadF S "b" (![refT (struct.t S)] "ns")) = #5);;
-    "ns" <-[refT (struct.t S)] NewS #();;
-    let: "p" := ref_to (refT (struct.t TwoInts)) (struct.fieldRef S "b" (![refT (struct.t S)] "ns")) in
-    struct.storeF TwoInts "x" (![refT (struct.t TwoInts)] "p") #5;;
-    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.loadF S "b" (![refT (struct.t S)] "ns")) = #5);;
-    "ns" <-[refT (struct.t S)] NewS #();;
-    "p" <-[refT (struct.t TwoInts)] struct.fieldRef S "b" (![refT (struct.t S)] "ns");;
-    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![refT (struct.t S)] "ns")) #5;;
-    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.load TwoInts (![refT (struct.t TwoInts)] "p")) = #5);;
-    "ns" <-[refT (struct.t S)] NewS #();;
-    "p" <-[refT (struct.t TwoInts)] struct.fieldRef S "b" (![refT (struct.t S)] "ns");;
-    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![refT (struct.t S)] "ns")) #5;;
-    "ok" <-[boolT] (![boolT] "ok") && (struct.loadF TwoInts "x" (![refT (struct.t TwoInts)] "p") = #5);;
+    let: "ns" := ref_to ptrT (NewS #()) in
+    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![ptrT] "ns")) #5;;
+    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.loadF S "b" (![ptrT] "ns")) = #5);;
+    "ns" <-[ptrT] NewS #();;
+    let: "p" := ref_to ptrT (struct.fieldRef S "b" (![ptrT] "ns")) in
+    struct.storeF TwoInts "x" (![ptrT] "p") #5;;
+    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.loadF S "b" (![ptrT] "ns")) = #5);;
+    "ns" <-[ptrT] NewS #();;
+    "p" <-[ptrT] struct.fieldRef S "b" (![ptrT] "ns");;
+    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![ptrT] "ns")) #5;;
+    "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.load TwoInts (![ptrT] "p")) = #5);;
+    "ns" <-[ptrT] NewS #();;
+    "p" <-[ptrT] struct.fieldRef S "b" (![ptrT] "ns");;
+    struct.storeF TwoInts "x" (struct.fieldRef S "b" (![ptrT] "ns")) #5;;
+    "ok" <-[boolT] (![boolT] "ok") && (struct.loadF TwoInts "x" (![ptrT] "p") = #5);;
     ![boolT] "ok".
-Theorem testNestedStructUpdates_t: ⊢ testNestedStructUpdates : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testNestedStructUpdates_t : types.
 
 Definition testStructConstructions: val :=
   rec: "testStructConstructions" <> :=
     let: "ok" := ref_to boolT #true in
-    let: "p1" := ref (zero_val (refT (struct.t TwoInts))) in
+    let: "p1" := ref (zero_val ptrT) in
     let: "p2" := ref (zero_val (struct.t TwoInts)) in
     let: "p3" := struct.mk TwoInts [
       "y" ::= #0;
@@ -1510,16 +1171,13 @@ Definition testStructConstructions: val :=
       "x" ::= #0;
       "y" ::= #0
     ] in
-    "ok" <-[boolT] (![boolT] "ok") && (![refT (struct.t TwoInts)] "p1" = #null);;
-    "p1" <-[refT (struct.t TwoInts)] struct.alloc TwoInts (zero_val (struct.t TwoInts));;
+    "ok" <-[boolT] (![boolT] "ok") && (![ptrT] "p1" = #null);;
+    "p1" <-[ptrT] struct.alloc TwoInts (zero_val (struct.t TwoInts));;
     "ok" <-[boolT] (![boolT] "ok") && (![struct.t TwoInts] "p2" = "p3");;
     "ok" <-[boolT] (![boolT] "ok") && ("p3" = "p4");;
-    "ok" <-[boolT] (![boolT] "ok") && ("p4" = struct.load TwoInts (![refT (struct.t TwoInts)] "p1"));;
-    "ok" <-[boolT] (![boolT] "ok") && ("p4" ≠ ![refT (struct.t TwoInts)] "p1");;
+    "ok" <-[boolT] (![boolT] "ok") && ("p4" = struct.load TwoInts (![ptrT] "p1"));;
+    "ok" <-[boolT] (![boolT] "ok") && ("p4" ≠ ![ptrT] "p1");;
     ![boolT] "ok".
-Theorem testStructConstructions_t: ⊢ testStructConstructions : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testStructConstructions_t : types.
 
 Definition testIncompleteStruct: val :=
   rec: "testIncompleteStruct" <> :=
@@ -1534,9 +1192,6 @@ Definition testIncompleteStruct: val :=
     "ok" <-[boolT] (![boolT] "ok") && (struct.get TwoInts "x" (struct.get S "b" "p2") = #0);;
     "ok" <-[boolT] (![boolT] "ok") && (struct.get S "c" "p2" = #false);;
     ![boolT] "ok".
-Theorem testIncompleteStruct_t: ⊢ testIncompleteStruct : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testIncompleteStruct_t : types.
 
 Definition StructWrap := struct.decl [
   "i" :: uint64T
@@ -1549,18 +1204,12 @@ Definition testStoreInStructVar: val :=
     ]) in
     struct.storeF StructWrap "i" "p" #5;;
     (struct.get StructWrap "i" (![struct.t StructWrap] "p") = #5).
-Theorem testStoreInStructVar_t: ⊢ testStoreInStructVar : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testStoreInStructVar_t : types.
 
 Definition testStoreInStructPointerVar: val :=
   rec: "testStoreInStructPointerVar" <> :=
-    let: "p" := ref_to (refT (struct.t StructWrap)) (struct.alloc StructWrap (zero_val (struct.t StructWrap))) in
-    struct.storeF StructWrap "i" (![refT (struct.t StructWrap)] "p") #5;;
-    (struct.loadF StructWrap "i" (![refT (struct.t StructWrap)] "p") = #5).
-Theorem testStoreInStructPointerVar_t: ⊢ testStoreInStructPointerVar : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testStoreInStructPointerVar_t : types.
+    let: "p" := ref_to ptrT (struct.alloc StructWrap (zero_val (struct.t StructWrap))) in
+    struct.storeF StructWrap "i" (![ptrT] "p") #5;;
+    (struct.loadF StructWrap "i" (![ptrT] "p") = #5).
 
 Definition testStoreComposite: val :=
   rec: "testStoreComposite" <> :=
@@ -1570,9 +1219,6 @@ Definition testStoreComposite: val :=
       "y" ::= #4
     ]);;
     (struct.get TwoInts "y" (struct.load TwoInts "p") = #4).
-Theorem testStoreComposite_t: ⊢ testStoreComposite : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testStoreComposite_t : types.
 
 Definition testStoreSlice: val :=
   rec: "testStoreSlice" <> :=
@@ -1580,9 +1226,6 @@ Definition testStoreSlice: val :=
     let: "s" := NewSlice uint64T #3 in
     "p" <-[slice.T uint64T] "s";;
     (slice.len (![slice.T uint64T] "p") = #3).
-Theorem testStoreSlice_t: ⊢ testStoreSlice : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testStoreSlice_t : types.
 
 (* vars.go *)
 
@@ -1591,9 +1234,6 @@ Definition testPointerAssignment: val :=
     let: "x" := ref (zero_val boolT) in
     "x" <-[boolT] #true;;
     ![boolT] "x".
-Theorem testPointerAssignment_t: ⊢ testPointerAssignment : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testPointerAssignment_t : types.
 
 Definition testAddressOfLocal: val :=
   rec: "testAddressOfLocal" <> :=
@@ -1601,34 +1241,24 @@ Definition testAddressOfLocal: val :=
     let: "xptr" := "x" in
     "xptr" <-[boolT] #true;;
     (![boolT] "x") && (![boolT] "xptr").
-Theorem testAddressOfLocal_t: ⊢ testAddressOfLocal : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testAddressOfLocal_t : types.
 
 Definition testAnonymousAssign: val :=
   rec: "testAnonymousAssign" <> :=
     #1 + #2;;
     #true.
-Theorem testAnonymousAssign_t: ⊢ testAnonymousAssign : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve testAnonymousAssign_t : types.
 
 (* wal.go *)
 
 (* 10 is completely arbitrary *)
 Definition MaxTxnWrites : expr := #10.
-Theorem MaxTxnWrites_t Γ : Γ ⊢ MaxTxnWrites : uint64T.
-Proof. typecheck. Qed.
 
 Definition logLength : expr := #1 + #2 * MaxTxnWrites.
-Theorem logLength_t Γ : Γ ⊢ logLength : uint64T.
-Proof. typecheck. Qed.
 
 Definition Log := struct.decl [
   "d" :: disk.Disk;
-  "l" :: lockRefT;
+  "l" :: ptrT;
   "cache" :: mapT disk.blockT;
-  "length" :: refT uint64T
+  "length" :: ptrT
 ].
 
 Definition intToBlock: val :=
@@ -1636,17 +1266,11 @@ Definition intToBlock: val :=
     let: "b" := NewSlice byteT disk.BlockSize in
     UInt64Put "b" "a";;
     "b".
-Theorem intToBlock_t: ⊢ intToBlock : (uint64T -> disk.blockT).
-Proof. typecheck. Qed.
-Hint Resolve intToBlock_t : types.
 
 Definition blockToInt: val :=
   rec: "blockToInt" "v" :=
     let: "a" := UInt64Get "v" in
     "a".
-Theorem blockToInt_t: ⊢ blockToInt : (disk.blockT -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve blockToInt_t : types.
 
 (* New initializes a fresh log *)
 Definition New: val :=
@@ -1668,25 +1292,16 @@ Definition New: val :=
       "length" ::= "lengthPtr";
       "l" ::= "l"
     ].
-Theorem New_t: ⊢ New : (unitT -> struct.t Log).
-Proof. typecheck. Qed.
-Hint Resolve New_t : types.
 
 Definition Log__lock: val :=
   rec: "Log__lock" "l" :=
     lock.acquire (struct.get Log "l" "l");;
     #().
-Theorem Log__lock_t: ⊢ Log__lock : (struct.t Log -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Log__lock_t : types.
 
 Definition Log__unlock: val :=
   rec: "Log__unlock" "l" :=
     lock.release (struct.get Log "l" "l");;
     #().
-Theorem Log__unlock_t: ⊢ Log__unlock : (struct.t Log -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Log__unlock_t : types.
 
 (* BeginTxn allocates space for a new transaction in the log.
 
@@ -1702,9 +1317,6 @@ Definition Log__BeginTxn: val :=
     else
       Log__unlock "l";;
       #false).
-Theorem Log__BeginTxn_t: ⊢ Log__BeginTxn : (struct.t Log -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve Log__BeginTxn_t : types.
 
 (* Read from the logical disk.
 
@@ -1721,17 +1333,11 @@ Definition Log__Read: val :=
       Log__unlock "l";;
       let: "dv" := disk.Read (logLength + "a") in
       "dv").
-Theorem Log__Read_t: ⊢ Log__Read : (struct.t Log -> uint64T -> disk.blockT).
-Proof. typecheck. Qed.
-Hint Resolve Log__Read_t : types.
 
 Definition Log__Size: val :=
   rec: "Log__Size" "l" :=
     let: "sz" := disk.Size #() in
     "sz" - logLength.
-Theorem Log__Size_t: ⊢ Log__Size : (struct.t Log -> uint64T).
-Proof. typecheck. Qed.
-Hint Resolve Log__Size_t : types.
 
 (* Write to the disk through the log. *)
 Definition Log__Write: val :=
@@ -1749,9 +1355,6 @@ Definition Log__Write: val :=
     struct.get Log "length" "l" <-[uint64T] "length" + #1;;
     Log__unlock "l";;
     #().
-Theorem Log__Write_t: ⊢ Log__Write : (struct.t Log -> uint64T -> disk.blockT -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Log__Write_t : types.
 
 (* Commit the current transaction. *)
 Definition Log__Commit: val :=
@@ -1762,9 +1365,6 @@ Definition Log__Commit: val :=
     let: "header" := intToBlock "length" in
     disk.Write #0 "header";;
     #().
-Theorem Log__Commit_t: ⊢ Log__Commit : (struct.t Log -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Log__Commit_t : types.
 
 Definition getLogEntry: val :=
   rec: "getLogEntry" "d" "logOffset" :=
@@ -1773,9 +1373,6 @@ Definition getLogEntry: val :=
     let: "a" := blockToInt "aBlock" in
     let: "v" := disk.Read ("diskAddr" + #1) in
     ("a", "v").
-Theorem getLogEntry_t: ⊢ getLogEntry : (disk.Disk -> uint64T -> (uint64T * disk.blockT)).
-Proof. typecheck. Qed.
-Hint Resolve getLogEntry_t : types.
 
 (* applyLog assumes we are running sequentially *)
 Definition applyLog: val :=
@@ -1790,18 +1387,12 @@ Definition applyLog: val :=
         Continue
       else Break));;
     #().
-Theorem applyLog_t: ⊢ applyLog : (disk.Disk -> uint64T -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve applyLog_t : types.
 
 Definition clearLog: val :=
   rec: "clearLog" "d" :=
     let: "header" := intToBlock #0 in
     disk.Write #0 "header";;
     #().
-Theorem clearLog_t: ⊢ clearLog : (disk.Disk -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve clearLog_t : types.
 
 (* Apply all the committed transactions.
 
@@ -1815,9 +1406,6 @@ Definition Log__Apply: val :=
     struct.get Log "length" "l" <-[uint64T] #0;;
     Log__unlock "l";;
     #().
-Theorem Log__Apply_t: ⊢ Log__Apply : (struct.t Log -> unitT).
-Proof. typecheck. Qed.
-Hint Resolve Log__Apply_t : types.
 
 (* Open recovers the log following a crash or shutdown *)
 Definition Open: val :=
@@ -1837,9 +1425,6 @@ Definition Open: val :=
       "length" ::= "lengthPtr";
       "l" ::= "l"
     ].
-Theorem Open_t: ⊢ Open : (unitT -> struct.t Log).
-Proof. typecheck. Qed.
-Hint Resolve Open_t : types.
 
 (* disabled since performance is quite poor *)
 Definition disabled_testWal: val :=
@@ -1856,6 +1441,3 @@ Definition disabled_testWal: val :=
     Log__Apply "lg";;
     "ok" <-[boolT] (![boolT] "ok") && (![uint64T] (struct.get Log "length" "lg") = #0);;
     ![boolT] "ok".
-Theorem disabled_testWal_t: ⊢ disabled_testWal : (unitT -> boolT).
-Proof. typecheck. Qed.
-Hint Resolve disabled_testWal_t : types.

--- a/internal/examples/simpledb/simpledb.gold.v
+++ b/internal/examples/simpledb/simpledb.gold.v
@@ -158,7 +158,7 @@ Definition tableRead: val :=
 
 Definition bufFile := struct.decl [
   "file" :: fileT;
-  "buf" :: refT (slice.T byteT)
+  "buf" :: ptrT
 ].
 
 Definition newBuf: val :=
@@ -196,7 +196,7 @@ Definition tableWriter := struct.decl [
   "index" :: mapT uint64T;
   "name" :: stringT;
   "file" :: struct.t bufFile;
-  "offset" :: refT uint64T
+  "offset" :: ptrT
 ].
 
 Definition newTableWriter: val :=
@@ -255,13 +255,13 @@ Definition tablePut: val :=
 
 (* Database is a handle to an open database. *)
 Definition Database := struct.decl [
-  "wbuffer" :: refT (mapT (slice.T byteT));
-  "rbuffer" :: refT (mapT (slice.T byteT));
-  "bufferL" :: lockRefT;
-  "table" :: struct.ptrT Table;
-  "tableName" :: refT stringT;
-  "tableL" :: lockRefT;
-  "compactionL" :: lockRefT
+  "wbuffer" :: ptrT;
+  "rbuffer" :: ptrT;
+  "bufferL" :: ptrT;
+  "table" :: ptrT;
+  "tableName" :: ptrT;
+  "tableL" :: ptrT;
+  "compactionL" :: ptrT
 ].
 
 Definition makeValueBuffer: val :=

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -35,10 +35,10 @@ Definition hasEndComment: val :=
 
 Definition condvarWrapping: val :=
   rec: "condvarWrapping" <> :=
-    let: "mu" := ref (zero_val lockRefT) in
-    "mu" <-[lockRefT] lock.new #();;
-    let: "cond1" := lock.newCond (![lockRefT] "mu") in
-    "mu" <-[lockRefT] lock.new #();;
+    let: "mu" := ref (zero_val ptrT) in
+    "mu" <-[ptrT] lock.new #();;
+    let: "cond1" := lock.newCond (![ptrT] "mu") in
+    "mu" <-[ptrT] lock.new #();;
     lock.condWait "cond1";;
     #().
 
@@ -362,7 +362,7 @@ Definition useCondVar: val :=
     #().
 
 Definition hasCondVar := struct.decl [
-  "cond" :: condvarRefT
+  "cond" :: ptrT
 ].
 
 (* log_debugging.go *)
@@ -567,8 +567,8 @@ Definition AssignNilSlice: val :=
 
 Definition AssignNilPointer: val :=
   rec: "AssignNilPointer" <> :=
-    let: "s" := NewSlice (refT uint64T) #4 in
-    SliceSet (refT uint64T) "s" #2 slice.nil;;
+    let: "s" := NewSlice ptrT #4 in
+    SliceSet ptrT "s" #2 slice.nil;;
     #().
 
 Definition CompareSliceToNil: val :=


### PR DESCRIPTION
This should be the goose-side changes of switching to an 'opaque' pointer type that does not track the pointee. For the purpose of the operational semantics, this is enough, and it avoids problems related to struct flattening and recursive types, and makes the generated code simpler. (https://github.com/tchajed/goose/issues/27 has been resolved, but Goose still sometimes prints `refT (struct.t MemKVClerk)` and sometimes `struct.ptrT MemKVClerk` -- these two terms are convertible now, but I am not sure why Goose fails to print the same type in a consistent way.)

Perennial still needs to be adjusted for this before we can land the change.