### PR TITLE
add semantic test for beyond-length subslicing

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -887,6 +887,10 @@ func (ctx Ctx) sliceExpr(e *ast.SliceExpr) coq.Expr {
 		ctx.unsupported(e, "3-index slice")
 		return nil
 	}
+	if e.Max != nil {
+		ctx.unsupported(e, "setting the max capacity in a slice expression is not supported")
+		return nil
+	}
 	x := ctx.expr(e.X)
 	if e.Low != nil && e.High == nil {
 		return coq.NewCallExpr("SliceSkip",

--- a/internal/examples/semantics/generated_test.go
+++ b/internal/examples/semantics/generated_test.go
@@ -407,6 +407,12 @@ func (suite *GoTestSuite) TestSliceOps() {
 	suite.Equal(true, testSliceOps())
 }
 
+func (suite *GoTestSuite) TestSliceCapacityOps() {
+	d := disk.NewMemDisk(30)
+	disk.Init(d)
+	suite.Equal(true, testSliceCapacityOps())
+}
+
 func (suite *GoTestSuite) TestOverwriteArray() {
 	d := disk.NewMemDisk(30)
 	disk.Init(d)

--- a/internal/examples/semantics/semantics.gold.v
+++ b/internal/examples/semantics/semantics.gold.v
@@ -1003,6 +1003,22 @@ Definition testSliceOps: val :=
     "ok" <-[boolT] (![boolT] "ok") && (![uint64T] "v4" = #10);;
     ![boolT] "ok".
 
+Definition testSliceCapacityOps: val :=
+  rec: "testSliceCapacityOps" <> :=
+    let: "x" := NewSlice uint64T #0 in
+    let: "sub1" := SliceTake "x" #6 in
+    SliceSet uint64T "sub1" #0 #1;;
+    let: "sub2" := SliceSubslice uint64T "x" #2 #4 in
+    SliceSet uint64T "sub2" #0 #2;;
+    let: "ok" := ref_to boolT #true in
+    "ok" <-[boolT] (![boolT] "ok") && (slice.len "sub1" = #6);;
+    "ok" <-[boolT] (![boolT] "ok") && (slice.cap "sub1" = #10);;
+    "ok" <-[boolT] (![boolT] "ok") && (SliceGet uint64T (SliceTake "x" #10) #0 = #1);;
+    "ok" <-[boolT] (![boolT] "ok") && (slice.len "sub2" = #2);;
+    "ok" <-[boolT] (![boolT] "ok") && (slice.cap "sub2" = #8);;
+    "ok" <-[boolT] (![boolT] "ok") && (SliceGet uint64T (SliceTake "x" #10) #2 = #2);;
+    ![boolT] "ok".
+
 Definition testOverwriteArray: val :=
   rec: "testOverwriteArray" <> :=
     let: "arr" := ref_to (slice.T uint64T) (NewSlice uint64T #4) in

--- a/internal/examples/semantics/semantics.gold.v
+++ b/internal/examples/semantics/semantics.gold.v
@@ -1005,7 +1005,7 @@ Definition testSliceOps: val :=
 
 Definition testSliceCapacityOps: val :=
   rec: "testSliceCapacityOps" <> :=
-    let: "x" := NewSlice uint64T #0 in
+    let: "x" := NewSliceWithCap uint64T #0 #10 in
     let: "sub1" := SliceTake "x" #6 in
     SliceSet uint64T "sub1" #0 #1;;
     let: "sub2" := SliceSubslice uint64T "x" #2 #4 in

--- a/internal/examples/semantics/slices.go
+++ b/internal/examples/semantics/slices.go
@@ -37,6 +37,25 @@ func testSliceOps() bool {
 	return ok
 }
 
+func testSliceCapacityOps() bool {
+	x := make([]uint64, 0, 10)
+
+	sub1 := x[:6]
+	sub1[0] = 1
+	sub2 := x[2:4]
+	sub2[0] = 2
+	// Doing something like `x[2:]` panics
+
+	var ok = true
+	ok = ok && (len(sub1) == 6)
+	ok = ok && (cap(sub1) == 10)
+	ok = ok && (x[:10][0] == 1) // affected by the sub1[0] assignment above
+	ok = ok && (len(sub2) == 2)
+	ok = ok && (cap(sub2) == 8)
+	ok = ok && (x[:10][2] == 2) // affected by the sub2[0] assignment above
+	return ok
+}
+
 func testOverwriteArray() bool {
 	var arr = make([]uint64, 4)
 


### PR DESCRIPTION
I still have to make sure this passes in Coq, though.