### PR TITLE
Multiple assignment

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -1665,7 +1665,7 @@ func (ctx Ctx) multipleAssignStmt(s *ast.AssignStmt) coq.Binding {
 
 	names := make([]string, len(s.Lhs))
 	for i := 0; i < len(names); i += 1 {
-		names[i] = fmt.Sprintf("ret%d", i)
+		names[i] = fmt.Sprintf("%d_ret", i)
 	}
 	multipleRetBinding := coq.Binding{Names: names, Expr: rhs}
 

--- a/goose.go
+++ b/goose.go
@@ -1640,12 +1640,50 @@ func (ctx Ctx) assignFromTo(s ast.Node,
 	return coq.Binding{}
 }
 
+func (ctx Ctx) multipleAssignStmt(s *ast.AssignStmt) coq.Binding {
+	// Translates a, b, c = SomeCall(args)
+	// into
+	//
+	// {
+	//   ret1, ret2, ret3 := SomeCall(args)
+	//   a = ret1
+	//   b = ret2
+	//   c = ret3
+	// }
+	//
+	// Returns multiple bindings, since there are multiple statements
+
+	if len(s.Rhs) > 1 {
+		ctx.unsupported(s, "multiple assignments on right hand side")
+	}
+	rhs := ctx.expr(s.Rhs[0])
+
+	if s.Tok != token.ASSIGN {
+		// This should be invalid Go syntax anyways
+		ctx.unsupported(s, "%v multiple assignment", s.Tok)
+	}
+
+	names := make([]string, len(s.Lhs))
+	for i := 0; i < len(names); i += 1 {
+		names[i] = fmt.Sprintf("ret%d", i)
+	}
+	multipleRetBinding := coq.Binding{Names: names, Expr: rhs}
+
+	coqStmts := make([]coq.Binding, len(s.Lhs)+1)
+	coqStmts[0] = multipleRetBinding
+
+	for i, name := range names {
+		coqStmts[i+1] = ctx.assignFromTo(s, s.Lhs[i], coq.IdentExpr(name))
+	}
+	return coq.Binding{Names: make([]string, 0), Expr: coq.BlockExpr{Bindings: coqStmts}}
+}
+
 func (ctx Ctx) assignStmt(s *ast.AssignStmt) coq.Binding {
 	if s.Tok == token.DEFINE {
 		return ctx.defineStmt(s)
 	}
-	if len(s.Lhs) > 1 || len(s.Rhs) > 1 {
-		ctx.unsupported(s, "multiple assignment")
+	if len(s.Lhs) > 1 {
+		return ctx.multipleAssignStmt(s)
 	}
 	lhs := s.Lhs[0]
 	rhs := ctx.expr(s.Rhs[0])

--- a/internal/examples/semantics/generated_test.go
+++ b/internal/examples/semantics/generated_test.go
@@ -245,6 +245,24 @@ func (suite *GoTestSuite) TestMapSize() {
 	suite.Equal(true, testMapSize())
 }
 
+func (suite *GoTestSuite) TestAssignTwo() {
+	d := disk.NewMemDisk(30)
+	disk.Init(d)
+	suite.Equal(true, testAssignTwo())
+}
+
+func (suite *GoTestSuite) TestAssignThree() {
+	d := disk.NewMemDisk(30)
+	disk.Init(d)
+	suite.Equal(true, testAssignThree())
+}
+
+func (suite *GoTestSuite) TestMultipleAssignToMap() {
+	d := disk.NewMemDisk(30)
+	disk.Init(d)
+	suite.Equal(true, testMultipleAssignToMap())
+}
+
 func (suite *GoTestSuite) TestReturnTwo() {
 	d := disk.NewMemDisk(30)
 	disk.Init(d)

--- a/internal/examples/semantics/multiple_assign.go
+++ b/internal/examples/semantics/multiple_assign.go
@@ -1,0 +1,31 @@
+package semantics
+
+func multReturnTwo() (uint64, uint64) {
+	return 2, 3
+}
+
+func testAssignTwo() bool {
+	var x uint64 = 10
+	var y uint64 = 15
+	x, y = multReturnTwo()
+	return x == 2 && y == 3
+}
+
+func multReturnThree() (uint64, bool, uint32) {
+	return 2, true, 1
+}
+
+func testAssignThree() bool {
+	var x uint64 = 10
+	var y bool = false
+	var z uint32 = 15
+	x, y, z = multReturnThree()
+	return x == 2 && y == true && z == 1
+}
+
+func testMultipleAssignToMap() bool {
+	var x uint64 = 10
+	var m = make(map[uint64]uint64)
+	x, m[0] = multReturnTwo()
+	return x == 2 && m[0] == 3
+}

--- a/internal/examples/semantics/semantics.gold.v
+++ b/internal/examples/semantics/semantics.gold.v
@@ -681,6 +681,45 @@ Definition testMapSize: val :=
     "ok" <-[boolT] (![boolT] "ok") && (MapLen "m" = #3);;
     ![boolT] "ok".
 
+(* multiple_assign.go *)
+
+Definition multReturnTwo: val :=
+  rec: "multReturnTwo" <> :=
+    (#2, #3).
+
+Definition testAssignTwo: val :=
+  rec: "testAssignTwo" <> :=
+    let: "x" := ref_to uint64T #10 in
+    let: "y" := ref_to uint64T #15 in
+    let: ("ret0", "ret1") := multReturnTwo #() in
+    "x" <-[uint64T] "ret0";;
+    "y" <-[uint64T] "ret1";;
+    (![uint64T] "x" = #2) && (![uint64T] "y" = #3).
+
+Definition multReturnThree: val :=
+  rec: "multReturnThree" <> :=
+    (#2, #true, #(U32 1)).
+
+Definition testAssignThree: val :=
+  rec: "testAssignThree" <> :=
+    let: "x" := ref_to uint64T #10 in
+    let: "y" := ref_to boolT #false in
+    let: "z" := ref_to uint32T (#(U32 15)) in
+    let: (("ret0", "ret1"), "ret2") := multReturnThree #() in
+    "x" <-[uint64T] "ret0";;
+    "y" <-[boolT] "ret1";;
+    "z" <-[uint32T] "ret2";;
+    (![uint64T] "x" = #2) && (![boolT] "y" = #true) && (![uint32T] "z" = #(U32 1)).
+
+Definition testMultipleAssignToMap: val :=
+  rec: "testMultipleAssignToMap" <> :=
+    let: "x" := ref_to uint64T #10 in
+    let: "m" := ref_to (mapT uint64T) (NewMap uint64T #()) in
+    let: ("ret0", "ret1") := multReturnTwo #() in
+    "x" <-[uint64T] "ret0";;
+    MapInsert (![mapT uint64T] "m") #0 "ret1";;
+    (![uint64T] "x" = #2) && (Fst (MapGet (![mapT uint64T] "m") #0) = #3).
+
 (* multiple_return.go *)
 
 Definition returnTwo: val :=

--- a/internal/examples/semantics/semantics.gold.v
+++ b/internal/examples/semantics/semantics.gold.v
@@ -691,9 +691,9 @@ Definition testAssignTwo: val :=
   rec: "testAssignTwo" <> :=
     let: "x" := ref_to uint64T #10 in
     let: "y" := ref_to uint64T #15 in
-    let: ("ret0", "ret1") := multReturnTwo #() in
-    "x" <-[uint64T] "ret0";;
-    "y" <-[uint64T] "ret1";;
+    let: ("0_ret", "1_ret") := multReturnTwo #() in
+    "x" <-[uint64T] "0_ret";;
+    "y" <-[uint64T] "1_ret";;
     (![uint64T] "x" = #2) && (![uint64T] "y" = #3).
 
 Definition multReturnThree: val :=
@@ -705,19 +705,19 @@ Definition testAssignThree: val :=
     let: "x" := ref_to uint64T #10 in
     let: "y" := ref_to boolT #false in
     let: "z" := ref_to uint32T (#(U32 15)) in
-    let: (("ret0", "ret1"), "ret2") := multReturnThree #() in
-    "x" <-[uint64T] "ret0";;
-    "y" <-[boolT] "ret1";;
-    "z" <-[uint32T] "ret2";;
+    let: (("0_ret", "1_ret"), "2_ret") := multReturnThree #() in
+    "x" <-[uint64T] "0_ret";;
+    "y" <-[boolT] "1_ret";;
+    "z" <-[uint32T] "2_ret";;
     (![uint64T] "x" = #2) && (![boolT] "y" = #true) && (![uint32T] "z" = #(U32 1)).
 
 Definition testMultipleAssignToMap: val :=
   rec: "testMultipleAssignToMap" <> :=
     let: "x" := ref_to uint64T #10 in
     let: "m" := ref_to (mapT uint64T) (NewMap uint64T #()) in
-    let: ("ret0", "ret1") := multReturnTwo #() in
-    "x" <-[uint64T] "ret0";;
-    MapInsert (![mapT uint64T] "m") #0 "ret1";;
+    let: ("0_ret", "1_ret") := multReturnTwo #() in
+    "x" <-[uint64T] "0_ret";;
+    MapInsert (![mapT uint64T] "m") #0 "1_ret";;
     (![uint64T] "x" = #2) && (Fst (MapGet (![mapT uint64T] "m") #0) = #3).
 
 (* multiple_return.go *)


### PR DESCRIPTION
I added support for multiple assignment. It was annoying to not have support for this when using the stateless marshaling library recently written by @RalfJung .

Now, code like
```
a, b = FunctionCall()
```
gets treated like
```
0_ret,1_ret := FunctionCall()
a = 0_ret
b = 1_ret
```
Support for the `0_ret, 1_ret := FunctionCall()` comes from the existing support for multiple defines in one statement. The reason for the funny variable names with a number at the front is so we can't accidentally shadow variables in the actual Go code.

If there are multiple multiple-assignment statements in block of code, then variables like `0_ret` getting shadowed for this to work.

There's still no support for multiple RHSs.