### PR TITLE
Recursive function support 🔁

### DIFF
--- a/internal/examples/unittest/recursive.go
+++ b/internal/examples/unittest/recursive.go
@@ -1,10 +1,25 @@
 package unittest
 
-/*
-func recur(n uint64) uint64 {
-	if n == 0 {
-		return 0
+// Should be able to detect even if in nested scopes.
+func recur1() {
+	if true {
+		recur1()
 	}
-	return n + recur(n-1)
 }
-*/
+
+type recurStruct1 struct{}
+
+func (s *recurStruct1) recur2() {
+	s.recur2()
+}
+
+type recurStruct2 struct {
+	lam func()
+}
+
+func (s *recurStruct2) recur3() {
+	s.lam = func() {
+		s.lam()
+	}
+	s.lam()
+}

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -762,6 +762,36 @@ Definition ReassignVars: val :=
 
 (* recursive.go *)
 
+(* Should be able to detect even if in nested scopes. *)
+Definition recur1: val :=
+  rec: "recur1" <> :=
+    (if: #true
+    then
+      "recur1" #();;
+      #()
+    else #()).
+
+Definition recurStruct1 := struct.decl [
+].
+
+Definition recurStruct1__recur2: val :=
+  rec: "recurStruct1__recur2" "s" :=
+    "recurStruct1__recur2" "s";;
+    #().
+
+Definition recurStruct2 := struct.decl [
+  "lam" :: (unitT -> unitT)%ht
+].
+
+Definition recurStruct2__recur3: val :=
+  rec: "recurStruct2__recur3" "s" :=
+    struct.storeF recurStruct2 "lam" "s" (λ: <>,
+      (struct.loadF recurStruct2 "lam" "s") #();;
+      #()
+      );;
+    (struct.loadF recurStruct2 "lam" "s") #();;
+    #().
+
 (* replicated_disk.go *)
 
 Definition Block := struct.decl [


### PR DESCRIPTION
Closes #39.

On recursive function detection:
1. I implemented a basic strategy. Starting from a func call ident, query the func object from the type checker, get the func body scope, and check if the call is contained within the scope.
2. I considered using `Scope.LookupParent`, but that didn't give me what I want since it finds the scope where the func def is. The func body scope is in a different place (see [type.Info.Scopes](https://pkg.go.dev/go/types#Info)).

On implementation:
1. I did a scan through all the call expr generation, and I figured I only needed to change two places: function calls and method calls.
2. The other call generations are special cased (e.g., calling interface methods), and I'm pretty sure they won't be recursive.

