### PR TITLE
Add support to goose type methods

### DIFF
--- a/internal/examples/unittest/ty_method.go
+++ b/internal/examples/unittest/ty_method.go
@@ -1,0 +1,26 @@
+package unittest
+
+type TyMethodSl []byte
+
+func (o TyMethodSl) func1() {}
+
+func (o *TyMethodSl) func2() {}
+
+type TyMethodInt uint64
+
+func (o TyMethodInt) func1() {}
+
+func (o *TyMethodInt) func2() {}
+
+// Test both ptr and direct receiver methods since there's a tricky corner case there.
+func TyMethodDriver() {
+	oSl := TyMethodSl([]byte{})
+	oSlPtr := &oSl
+	oSl.func1()
+	oSlPtr.func2()
+
+	oInt := TyMethodInt(1)
+	oIntPtr := &oInt
+	oInt.func1()
+	oIntPtr.func2()
+}

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -1084,6 +1084,41 @@ Definition mkNothing: val :=
     mkInt #();;
     #().
 
+(* ty_method.go *)
+
+Definition TyMethodSl: ty := slice.T byteT.
+
+Definition TyMethodSl__func1: val :=
+  rec: "TyMethodSl__func1" "o" :=
+    #().
+
+Definition TyMethodSl__func2: val :=
+  rec: "TyMethodSl__func2" "o" :=
+    #().
+
+Definition TyMethodInt: ty := uint64T.
+
+Definition TyMethodInt__func1: val :=
+  rec: "TyMethodInt__func1" "o" :=
+    #().
+
+Definition TyMethodInt__func2: val :=
+  rec: "TyMethodInt__func2" "o" :=
+    #().
+
+(* Test both ptr and direct receiver methods since there's a tricky corner case there. *)
+Definition TyMethodDriver: val :=
+  rec: "TyMethodDriver" <> :=
+    let: "oSl" := NewSlice byteT #0 in
+    let: "oSlPtr" := "oSl" in
+    TyMethodSl__func1 "oSl";;
+    TyMethodSl__func2 "oSlPtr";;
+    let: "oInt" := #1 in
+    let: "oIntPtr" := "oInt" in
+    TyMethodInt__func1 "oInt";;
+    TyMethodInt__func2 "oIntPtr";;
+    #().
+
 (* type_alias.go *)
 
 Definition my_u64: ty := uint64T.


### PR DESCRIPTION
See the unit test for an example.

I chose to Goose them the same way we Goose struct methods. The main annoyance was on reducing the special-casing for structs, both in func decl generation and method selector generation.

While writing this, I noticed the logic sprinkled around for handling normal types vs ptrs to types. The code I wrote worked with this trickiness, but maybe with @upamanyus's new heap allocation work, we won't need it?