### PR TITLE
Add proof-setup utility to start proofs

### DIFF
--- a/cmd/proof-setup/main.go
+++ b/cmd/proof-setup/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/goose-lang/goose/proofsetup"
+	"github.com/goose-lang/goose/util"
+	"golang.org/x/tools/go/packages"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintln(flag.CommandLine.Output(), "Usage: proof-setup [options] <package patterns>")
+
+		flag.PrintDefaults()
+	}
+
+	var modDir string
+	flag.StringVar(&modDir, "dir", ".",
+		"directory containing necessary go.mod")
+
+	flag.Parse()
+	pkgPatterns := flag.Args()
+
+	pkgs, err := packages.Load(util.NewPackageConfig(modDir, false), pkgPatterns...)
+	if err != nil {
+		panic(err)
+	} else if len(pkgs) == 0 {
+		panic("patterns matched no packages")
+	}
+
+	blue := color.New(color.FgBlue).SprintfFunc()
+
+	for _, pkg := range pkgs {
+		pf := proofsetup.New(pkg)
+		fmt.Printf("%s:\n", blue(pf.ProofPath))
+		fmt.Printf(pf.SkeletonFile())
+	}
+}

--- a/proofgen/names.go
+++ b/proofgen/names.go
@@ -32,7 +32,7 @@ func (tr *namesTranslator) Decl(d ast.Decl) {
 					if name.Name != "_" && tr.filter.GetAction(name.Name) == declfilter.Translate {
 						tr.vars = append(tr.vars, tmpl.Variable{
 							Name:    name.Name,
-							CoqType: toCoqType(info.TypeOf(name), tr.pkg),
+							CoqType: ToCoqType(info.TypeOf(name), tr.pkg),
 						})
 					}
 				}

--- a/proofgen/types.go
+++ b/proofgen/types.go
@@ -65,7 +65,8 @@ func (tr *typesTranslator) toCoqTypeWithDeps(t types.Type) string {
 	panic(fmt.Sprintf("Unknown type %v (of type %T)", t, t))
 }
 
-func toGooseLangType(t types.Type) glang.Type {
+// toGlangType converts a Go type to a GooseLang type
+func toGlangType(t types.Type) glang.Type {
 	if tr := goose.SimpleType(t); tr != nil {
 		return tr
 	}
@@ -74,14 +75,14 @@ func toGooseLangType(t types.Type) glang.Type {
 		// type parameters for proofgen are bound Gallina variables
 		return glang.TypeIdent(t.Obj().Name())
 	case *types.Map:
-		keyT := toGooseLangType(t.Key())
-		valueT := toGooseLangType(t.Elem())
+		keyT := toGlangType(t.Key())
+		valueT := toGlangType(t.Elem())
 		return glang.MapType{
 			Key:   keyT,
 			Value: valueT,
 		}
 	case *types.Chan:
-		elemT := toGooseLangType(t.Elem())
+		elemT := toGlangType(t.Elem())
 		return glang.ChanType{
 			Elem: elemT,
 		}
@@ -98,13 +99,13 @@ func toGooseLangType(t types.Type) glang.Type {
 		}
 		return glang.TypeIdent(fmt.Sprintf("%s.%s", pkg, name))
 	}
-	panic(fmt.Sprintf("toGooseLangType: unimplemented proofgen support for type %v (of type %T)", t, t))
+	panic(fmt.Sprintf("toGolangType: unimplemented proofgen support for type %v (of type %T)", t, t))
 }
 
 func convertTypeArgsToGlang(typeList *types.TypeList) (glangTypeArgs []glang.Type) {
 	glangTypeArgs = make([]glang.Type, typeList.Len())
 	for i := range glangTypeArgs {
-		glangTypeArgs[i] = toGooseLangType(typeList.At(i))
+		glangTypeArgs[i] = toGlangType(typeList.At(i))
 	}
 	return
 }
@@ -173,7 +174,7 @@ func (tr *typesTranslator) translateStructType(spec *ast.TypeSpec, s *types.Stru
 		if info.IsGooseLang {
 			// proofgen's GooseLang type translation isn't perfect and is only needed
 			// for generic structs, so don't attempt to translate unless needed
-			field.GoType = toGooseLangType(s.Field(i).Type()).Gallina(false)
+			field.GoType = toGlangType(s.Field(i).Type()).Gallina(false)
 		}
 		info.Fields = append(info.Fields, field)
 	}

--- a/proofgen/util.go
+++ b/proofgen/util.go
@@ -51,21 +51,22 @@ func namedTypeToCoq(t *types.Named, pkg *packages.Package) string {
 			params = append(params, "#()")
 		}
 		for i := 0; i < t.TypeArgs().Len(); i++ {
-			params = append(params, toCoqType(t.TypeArgs().At(i), pkg))
+			params = append(params, ToCoqType(t.TypeArgs().At(i), pkg))
 		}
 		return fmt.Sprintf("(%s %s)", baseName, strings.Join(params, " "))
 	}
 	return baseName
 }
 
-func toCoqType(t types.Type, pkg *packages.Package) string {
+// ToCoqType converts a type to a Gallina type modeling that type
+func ToCoqType(t types.Type, pkg *packages.Package) string {
 	switch t := types.Unalias(t).(type) {
 	case *types.Basic:
 		return basicTypeToCoq(t)
 	case *types.Slice:
 		return "slice.t"
 	case *types.Array:
-		return fmt.Sprintf("(vec %s (uint.nat (W64 %d)))", toCoqType(t.Elem(), pkg), t.Len())
+		return fmt.Sprintf("(vec %s (uint.nat (W64 %d)))", ToCoqType(t.Elem(), pkg), t.Len())
 	case *types.Pointer:
 		return "loc"
 	case *types.Signature:

--- a/proofsetup/proofsetup.go
+++ b/proofsetup/proofsetup.go
@@ -1,0 +1,117 @@
+package proofsetup
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"slices"
+	"strings"
+	"text/template"
+
+	"github.com/goose-lang/goose/glang"
+	"github.com/goose-lang/goose/util"
+	"github.com/pkg/errors"
+	"golang.org/x/tools/go/packages"
+)
+
+// Initial plan: emit skeleton file and its correct path for copy-pasting
+//
+// Eventually, try to update a proof file, especially imports and new WP lemmas.
+
+type ProofSetup struct {
+	ProofPath   string
+	PackageName string
+	Imports     string
+	ContextVars string
+	WpLemmas    []string
+}
+
+// Coq qualified name for a package. Typically called on (pkg.PkgPath, pkg.Name).
+func pkgImport(pkgPath string, pkgName string) string {
+	fsPath := glang.ThisIsBadAndShouldBeDeprecatedGoPathToCoqPath(path.Dir(pkgPath))
+	importPrefix := strings.ReplaceAll(fsPath, "/", ".")
+	if !strings.Contains(pkgPath, "/") {
+		return pkgName
+	}
+	return importPrefix + "." + pkgName
+}
+
+func pkgCoqImports(pkg *packages.Package) []string {
+	ffi := util.GetFfi(pkg)
+	var imports []string
+	for _, p := range pkg.Imports {
+		imports = append(imports,
+			fmt.Sprintf("New.proof.%s", pkgImport(p.PkgPath, p.Name)))
+	}
+	slices.Sort(imports)
+	ffiImportName := ffi
+	if ffi == "" {
+		ffiImportName = "proof"
+	}
+	imports = append(imports,
+		fmt.Sprintf("New.proof.%s_prelude", ffiImportName))
+	imports = append(imports,
+		fmt.Sprintf("New.generatedproof.%s", pkgImport(pkg.PkgPath, pkg.Name)))
+	return imports
+}
+
+func importToRequireImport(coqPkgName string) string {
+	i := strings.LastIndex(coqPkgName, ".")
+	if i < 0 {
+		panic(errors.Errorf("unexpected coqPkgName %s", coqPkgName))
+	}
+	return fmt.Sprintf("From %s Require Import %s.", coqPkgName[:i], coqPkgName[i+1:])
+}
+
+func New(pkg *packages.Package) ProofSetup {
+	ffi := util.GetFfi(pkg)
+	s := ProofSetup{
+		PackageName: pkg.Name,
+	}
+
+	s.ProofPath = path.Join(
+		"new/proof/",
+		glang.ThisIsBadAndShouldBeDeprecatedGoPathToCoqPath(path.Dir(pkg.PkgPath)),
+		pkg.Name+".v",
+	)
+
+	var importLines []string
+	imports := pkgCoqImports(pkg)
+	for _, coqName := range imports {
+		importLines = append(importLines, importToRequireImport(coqName))
+	}
+	s.Imports = strings.Join(importLines, "\n")
+
+	if ffi == "" {
+		s.ContextVars = "Context `{hG: heapGS Σ, !ffi_semantics _ _} `{!goGlobalsGS Σ}."
+	} else {
+		s.ContextVars = "Context `{hG: heapGS Σ} `{!goGlobalsGS Σ}."
+	}
+
+	s.WpLemmas = packageWps(pkg)
+
+	return s
+}
+
+func (pf ProofSetup) SkeletonFile() string {
+	tmpl := template.Must(template.New("proof.v").Parse(`{{.Imports}}
+
+Section proof.
+{{.ContextVars}}
+
+#[global] Program Instance : IsPkgInit {{.PackageName}} := ltac2:(build_is_pkg_init ()).
+
+{{ range $lemma := .WpLemmas -}}
+{{$lemma}}
+Proof. Admitted.
+
+{{ end -}}
+End proof.
+`))
+	s := new(bytes.Buffer)
+	err := tmpl.Execute(s, pf)
+	if err != nil {
+		panic(fmt.Errorf("internal error: executing template: %v", err))
+	}
+	return s.String()
+}

--- a/proofsetup/proofsetup.go
+++ b/proofsetup/proofsetup.go
@@ -99,7 +99,7 @@ func (pf ProofSetup) SkeletonFile() string {
 Section proof.
 {{.ContextVars}}
 
-#[global] Program Instance : IsPkgInit {{.PackageName}} := ltac2:(build_is_pkg_init ()).
+#[global] Program Instance : IsPkgInit {{.PackageName}} := ltac2:(build_pkg_init ()).
 
 {{ range $lemma := .WpLemmas -}}
 {{$lemma}}

--- a/proofsetup/proofsetup.go
+++ b/proofsetup/proofsetup.go
@@ -85,7 +85,7 @@ func New(pkg *packages.Package) ProofSetup {
 	if ffi == "" {
 		s.ContextVars = "Context `{hG: heapGS Σ, !ffi_semantics _ _} `{!goGlobalsGS Σ}."
 	} else {
-		s.ContextVars = "Context `{hG: heapGS Σ} `{!goGlobalsGS Σ}."
+		s.ContextVars = "Context `{hG: !heapGS Σ} `{!goGlobalsGS Σ}."
 	}
 
 	s.WpLemmas = packageWps(pkg)

--- a/proofsetup/proofsetup_test.go
+++ b/proofsetup/proofsetup_test.go
@@ -1,0 +1,28 @@
+package proofsetup
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/goose-lang/goose/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+func TestNewSetup(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	os.Chdir("..")
+	pkgs, err := packages.Load(util.NewPackageConfig("./testdata/examples", false), "./semantics")
+	require.NoError(err, "internal error: could not load test")
+	require.Len(pkgs, 1, "internal error")
+	pkg := pkgs[0]
+	pf := New(pkg)
+	assert.Equal(path.Join("new/proof",
+		"github_com/goose_lang/goose/testdata/examples",
+		"semantics.v",
+	), pf.ProofPath)
+	_ = pf.SkeletonFile()
+}

--- a/proofsetup/wp.go
+++ b/proofsetup/wp.go
@@ -1,0 +1,117 @@
+package proofsetup
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"github.com/goose-lang/goose/proofgen"
+	"github.com/pkg/errors"
+	"golang.org/x/tools/go/packages"
+)
+
+type receiverType struct {
+	Name    string
+	Pointer bool
+}
+
+func (rt receiverType) FullName() string {
+	if rt.Pointer {
+		return rt.Name + "'ptr"
+	} else {
+		return rt.Name
+	}
+}
+
+// getReceiverType extracts information about the receiver of a method
+func getReceiverType(t types.Type) receiverType {
+	switch t := types.Unalias(t).(type) {
+	case *types.Named:
+		return receiverType{
+			Name:    t.Obj().Name(),
+			Pointer: false,
+		}
+	case *types.Pointer:
+		underlyingT := types.Unalias(t.Elem()).(*types.Named)
+		return receiverType{
+			Name:    underlyingT.Obj().Name(),
+			Pointer: true,
+		}
+	}
+	panic(errors.Errorf("unexpected receiver type %v", t))
+}
+
+func argGallinaBinder(pkg *packages.Package, x *ast.Ident) string {
+	ty := proofgen.ToCoqType(pkg.TypesInfo.TypeOf(x), pkg)
+	return fmt.Sprintf("(%s: %s)", x.Name, ty)
+}
+
+func funcDeclToWp(pkg *packages.Package, decl *ast.FuncDecl) string {
+	s := new(bytes.Buffer)
+
+	var rt *receiverType = nil
+	if decl.Recv != nil {
+		recv := decl.Recv.List[0].Names[0]
+		t := pkg.TypesInfo.TypeOf(recv)
+		actualRt := getReceiverType(t)
+		rt = &actualRt
+	}
+
+	var gallinaBinders []string
+	var args []string
+	// TODO: binder for rt
+	if rt != nil {
+		recv := decl.Recv.List[0].Names[0]
+		gallinaBinders = append(gallinaBinders, argGallinaBinder(pkg, recv))
+	}
+	for _, param := range decl.Type.Params.List {
+		for _, arg := range param.Names {
+			args = append(args, fmt.Sprintf("#%s", arg.Name))
+			gallinaBinders = append(gallinaBinders, argGallinaBinder(pkg, arg))
+		}
+	}
+	if len(args) == 0 {
+		args = []string{"#()"}
+	}
+
+	if decl.Type.TypeParams != nil {
+		var args []string
+		for _, param := range decl.Type.TypeParams.List {
+			for _, name := range param.Names {
+				args = append(args, name.Name)
+			}
+		}
+		fmt.Fprintf(s, "(* generic arguments %s not handled *)\n", strings.Join(args, " "))
+	}
+	if rt != nil {
+		fmt.Fprintf(s, "Lemma wp_%s__%s %s :\n", rt.Name, decl.Name, strings.Join(gallinaBinders, " "))
+	} else {
+		fmt.Fprintf(s, "Lemma wp_%s %s :\n", decl.Name, strings.Join(gallinaBinders, " "))
+	}
+
+	fmt.Fprintf(s, "  {{{ is_pkg_init %s }}}\n", pkg.Name)
+
+	if rt == nil {
+		fmt.Fprintf(s, "    %s @ \"%s\" %s\n", pkg.Name, decl.Name, strings.Join(args, " "))
+	} else {
+		recv := decl.Recv.List[0].Names[0]
+		fmt.Fprintf(s, "    %s @ %s @ \"%s\" @ \"%s\" %s\n", recv.Name, pkg.Name, rt.FullName(), decl.Name, strings.Join(args, " "))
+	}
+
+	fmt.Fprintf(s, "  {{{ RET #(); True }}}.")
+	return s.String()
+}
+
+func packageWps(pkg *packages.Package) []string {
+	var wps []string
+	for _, f := range pkg.Syntax {
+		for _, decl := range f.Decls {
+			if decl, ok := decl.(*ast.FuncDecl); ok {
+				wps = append(wps, funcDeclToWp(pkg, decl))
+			}
+		}
+	}
+	return wps
+}


### PR DESCRIPTION
Here's a quick demo:

```sh
$ go run ./cmd/proof-setup -dir ~/sw/tulip ./index
new/proof/github_com/mit_pdos/tulip/index.v:
From New.proof.github_com.mit_pdos.tulip Require Import tuple.
From New.proof Require Import sync.
From New.proof Require Import grove_prelude.
From New.generatedproof.github_com.mit_pdos.tulip Require Import index.

Section proof.
Context `{hG: !heapGS Σ} `{!goGlobalsGS Σ}.

#[global] Program Instance : IsPkgInit index := ltac2:(build_pkg_init ()).

Lemma wp_Index__GetTuple (idx: loc) (key: go_string) :
  {{{ is_pkg_init index }}}
    idx @ index @ "Index'ptr" @ "GetTuple" #key
  {{{ RET #(); True }}}.
Proof. Admitted.

Lemma wp_MkIndex  :
  {{{ is_pkg_init index }}}
    index @ "MkIndex" #()
  {{{ RET #(); True }}}.
Proof. Admitted.

End proof.
```