### PR TITLE
Pass type args when they appear in function calls.

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -804,6 +804,8 @@ func (ctx *Ctx) selectorExpr(e *ast.SelectorExpr) glang.Expr {
 			// return glang.IdentExpr(fmt.Sprintf("global:%s", e.Sel.Name))
 		} else if f, ok := ctx.info.ObjectOf(e.Sel).(*types.Func); ok {
 			pkg := f.Pkg()
+			// If there are type arguments, we must pass them
+			typeArgs := ctx.info.Instances[e.Sel].TypeArgs
 			pkgIdent := fmt.Sprintf("%s.%s", filepath.Base(pkg.Path()), pkg.Name())
 			return ctx.handleImplicitConversion(e,
 				ctx.info.TypeOf(e.Sel),
@@ -812,6 +814,8 @@ func (ctx *Ctx) selectorExpr(e *ast.SelectorExpr) glang.Expr {
 					glang.GallinaIdent("func_call"),
 					glang.StringVal{Value: glang.GallinaIdent(pkgIdent)},
 					glang.StringVal{Value: glang.StringLiteral{Value: e.Sel.Name}},
+				).Append(
+					typesToExprs(ctx.convertTypeArgsToGlang(nil, typeArgs))...,
 				),
 			)
 		} else {

--- a/model/channel/channel.go
+++ b/model/channel/channel.go
@@ -56,15 +56,11 @@ func (c *Channel[T]) Send(val T) {
 	}
 
 	// Create a send case for this channel
-	var send_case SelectCase[T] = SelectCase[T]{
-		channel: c,
-		dir:     SelectSend,
-		Value:   val,
-	}
+	sendCase := NewSendCase(c, val)
 
 	// Run a blocking select with just this one case
 	// This will block until the send succeeds
-	Select1(&send_case, true)
+	Select1(sendCase, true)
 }
 
 // Equivalent to:
@@ -84,7 +80,7 @@ func (c *Channel[T]) Receive() (T, bool) {
 
 	// Run a blocking select with just this one case
 	// This will block until the receive succeeds
-	Select1(&recvCase, true)
+	Select1(recvCase, true)
 
 	return recvCase.Value, recvCase.Ok
 }
@@ -618,16 +614,16 @@ func TrySelect[T any](select_case *SelectCase[T]) bool {
 	return false
 }
 
-func NewSendCase[T any](channel *Channel[T], value T) SelectCase[T] {
-	return SelectCase[T]{
+func NewSendCase[T any](channel *Channel[T], value T) *SelectCase[T] {
+	return &SelectCase[T]{
 		channel: channel,
 		dir:     SelectSend,
 		Value:   value,
 	}
 }
 
-func NewRecvCase[T any](channel *Channel[T]) SelectCase[T] {
-	return SelectCase[T]{
+func NewRecvCase[T any](channel *Channel[T]) *SelectCase[T] {
+	return &SelectCase[T]{
 		channel: channel,
 		dir:     SelectRecv,
 	}

--- a/testdata/examples/channel/channel.gold.v
+++ b/testdata/examples/channel/channel.gold.v
@@ -17,7 +17,7 @@ Definition SendMessage : val :=
   rec: "SendMessage" <> :=
     exception_do (let: "messageChan" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
-    (func_call #channel.channel #"NewChannelRef"%go) "$a0") in
+    (func_call #channel.channel #"NewChannelRef"%go #stringT) "$a0") in
     do:  ("messageChan" <-[#ptrT] "$r0");;;
     let: "$go" := (λ: <>,
       exception_do (do:  (let: "$a0" := #"hello world"%go in
@@ -43,7 +43,7 @@ Definition JoinWithReceive : val :=
     do:  ("message" <-[#ptrT] "$r0");;;
     let: "done" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
-    (func_call #channel.channel #"NewChannelRef"%go) "$a0") in
+    (func_call #channel.channel #"NewChannelRef"%go #uint64T) "$a0") in
     do:  ("done" <-[#ptrT] "$r0");;;
     let: "$go" := (λ: <>,
       exception_do (let: "$r0" := #"hello world"%go in
@@ -69,7 +69,7 @@ Definition JoinWithSend : val :=
     do:  ("message" <-[#ptrT] "$r0");;;
     let: "done" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
-    (func_call #channel.channel #"NewChannelRef"%go) "$a0") in
+    (func_call #channel.channel #"NewChannelRef"%go #uint64T) "$a0") in
     do:  ("done" <-[#ptrT] "$r0");;;
     let: "$go" := (λ: <>,
       exception_do (let: "$r0" := #"hello world"%go in
@@ -93,19 +93,19 @@ Definition BroadcastNotification : val :=
   rec: "BroadcastNotification" <> :=
     exception_do (let: "notifyCh" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
-    (func_call #channel.channel #"NewChannelRef"%go) "$a0") in
+    (func_call #channel.channel #"NewChannelRef"%go #uint64T) "$a0") in
     do:  ("notifyCh" <-[#ptrT] "$r0");;;
     let: "done1" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
-    (func_call #channel.channel #"NewChannelRef"%go) "$a0") in
+    (func_call #channel.channel #"NewChannelRef"%go #uint64T) "$a0") in
     do:  ("done1" <-[#ptrT] "$r0");;;
     let: "done2" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
-    (func_call #channel.channel #"NewChannelRef"%go) "$a0") in
+    (func_call #channel.channel #"NewChannelRef"%go #uint64T) "$a0") in
     do:  ("done2" <-[#ptrT] "$r0");;;
     let: "done3" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
-    (func_call #channel.channel #"NewChannelRef"%go) "$a0") in
+    (func_call #channel.channel #"NewChannelRef"%go #uint64T) "$a0") in
     do:  ("done3" <-[#ptrT] "$r0");;;
     let: "results" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "results") in
@@ -200,11 +200,11 @@ Definition CoordinatedChannelClose : val :=
   rec: "CoordinatedChannelClose" <> :=
     exception_do (let: "bufCh" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := #(W64 2) in
-    (func_call #channel.channel #"NewChannelRef"%go) "$a0") in
+    (func_call #channel.channel #"NewChannelRef"%go #uint64T) "$a0") in
     do:  ("bufCh" <-[#ptrT] "$r0");;;
     let: "syncCh" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
-    (func_call #channel.channel #"NewChannelRef"%go) "$a0") in
+    (func_call #channel.channel #"NewChannelRef"%go #uint64T) "$a0") in
     do:  ("syncCh" <-[#ptrT] "$r0");;;
     let: "$go" := (λ: <>,
       exception_do (do:  (let: "$a0" := #(W64 42) in


### PR DESCRIPTION
Static functions with type args need to pass the type arg in the translated goose code, which I need in order to use NewChannelRef in the channel model. 

Unrelated: Also made the select case functions return a pointer since it is easier to work with