### PR TITLE
Refactors to channel model and move tests to new branch.

### DIFF
--- a/model/channel/channel.go
+++ b/model/channel/channel.go
@@ -135,10 +135,10 @@ func (c *Channel[T]) ReceiveDiscardOk() T {
 func (c *Channel[T]) BufferedTryReceiveLocked() (bool, T, bool) {
 	var v T
 	if c.count > 0 {
-		v = c.buffer[c.first]
+		c.v = c.buffer[c.first]
 		c.first = (c.first + 1) % uint64(len(c.buffer))
 		c.count -= 1
-		return true, v, true
+		return true, c.v, true
 	}
 	if c.state == closed {
 		return true, v, false

--- a/model/channel/channel.go
+++ b/model/channel/channel.go
@@ -437,20 +437,16 @@ func Select2[T1, T2 any](
 	blocking bool) uint64 {
 
 	i := primitive.RandomUint64() % uint64(2)
-	var selected bool
-	selected = TrySelectCase2(i, case1, case2)
-	if selected {
+	if TrySelectCase2(i, case1, case2) {
 		return i
 	}
 
 	// If nothing was selected and we're blocking, try in a loop
 	for {
-		selected = TrySelect(case1)
-		if selected {
+		if TrySelect(case1) {
 			return 0
 		}
-		selected = TrySelect(case2)
-		if selected {
+		if TrySelect(case2) {
 			return 1
 		}
 		if !blocking {
@@ -483,23 +479,18 @@ func Select3[T1, T2, T3 any](
 	blocking bool) uint64 {
 
 	i := primitive.RandomUint64() % uint64(3)
-	var selected bool
-	selected = TrySelectCase3(i, case1, case2, case3)
-	if selected {
+	if TrySelectCase3(i, case1, case2, case3) {
 		return i
 	}
 
 	for {
-		selected = TrySelect(case1)
-		if selected {
+		if TrySelect(case1) {
 			return 0
 		}
-		selected = TrySelect(case2)
-		if selected {
+		if TrySelect(case2) {
 			return 1
 		}
-		selected = TrySelect(case3)
-		if selected {
+		if TrySelect(case3) {
 			return 2
 		}
 		if !blocking {
@@ -537,27 +528,21 @@ func Select4[T1, T2, T3, T4 any](
 	blocking bool) uint64 {
 
 	i := primitive.RandomUint64() % uint64(4)
-	var selected bool
-	selected = TrySelectCase4(i, case1, case2, case3, case4)
-	if selected {
+	if TrySelectCase4(i, case1, case2, case3, case4) {
 		return i
 	}
 
 	for {
-		selected = TrySelect(case1)
-		if selected {
+		if TrySelect(case1) {
 			return 0
 		}
-		selected = TrySelect(case2)
-		if selected {
+		if TrySelect(case2) {
 			return 1
 		}
-		selected = TrySelect(case3)
-		if selected {
+		if TrySelect(case3) {
 			return 2
 		}
-		selected = TrySelect(case4)
-		if selected {
+		if TrySelect(case4) {
 			return 3
 		}
 		if !blocking {
@@ -600,31 +585,24 @@ func Select5[T1, T2, T3, T4, T5 any](
 	blocking bool) uint64 {
 
 	i := primitive.RandomUint64() % uint64(5)
-	var selected bool
-	selected = TrySelectCase5(i, case1, case2, case3, case4, case5)
-	if selected {
+	if TrySelectCase5(i, case1, case2, case3, case4, case5) {
 		return i
 	}
 
 	for {
-		selected = TrySelect(case1)
-		if selected {
+		if TrySelect(case1) {
 			return 0
 		}
-		selected = TrySelect(case2)
-		if selected {
+		if TrySelect(case2) {
 			return 1
 		}
-		selected = TrySelect(case3)
-		if selected {
+		if TrySelect(case3) {
 			return 2
 		}
-		selected = TrySelect(case4)
-		if selected {
+		if TrySelect(case4) {
 			return 3
 		}
-		selected = TrySelect(case5)
-		if selected {
+		if TrySelect(case5) {
 			return 4
 		}
 		if !blocking {

--- a/model/channel/channel_test.go
+++ b/model/channel/channel_test.go
@@ -1,4 +1,4 @@
-package chan_test
+package channel
 
 /*
 Tests to demonstrate Go's behavior on various subtle examples.
@@ -12,8 +12,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/goose-lang/goose/model/channel"
 )
 
 // The channel tests below are for the Goose model of channels that is implemented as a Go
@@ -28,7 +26,7 @@ func TestChan(t *testing.T) {
 	for chanCap := uint64(0); chanCap < N; chanCap++ {
 		{
 			// Ensure that receive from empty chan blocks.
-			c := channel.NewChannelRef[uint64](chanCap)
+			c := NewChannelRef[uint64](chanCap)
 			recv1 := false
 			go func() {
 				_, _ = c.Receive()
@@ -60,7 +58,7 @@ func TestChan(t *testing.T) {
 
 		{
 			// Ensure that send to full chan blocks.
-			c := channel.NewChannelRef[uint64](chanCap)
+			c := NewChannelRef[uint64](chanCap)
 			for i := uint64(0); i < chanCap; i++ {
 				c.Send(i)
 			}
@@ -82,7 +80,7 @@ func TestChan(t *testing.T) {
 
 		{
 			// Ensure that we receive 0 from closed chan.
-			c := channel.NewChannelRef[uint64](chanCap)
+			c := NewChannelRef[uint64](chanCap)
 			for i := uint64(0); i < chanCap; i++ {
 				c.Send(i)
 			}
@@ -103,8 +101,8 @@ func TestChan(t *testing.T) {
 
 		{
 			// Ensure that close unblocks receive.
-			c := channel.NewChannelRef[uint64](chanCap)
-			done := channel.NewChannelRef[bool](0)
+			c := NewChannelRef[uint64](chanCap)
+			done := NewChannelRef[bool](0)
 			go func() {
 				v, ok := c.Receive()
 				done.Send(v == 0 && ok == false)
@@ -120,7 +118,7 @@ func TestChan(t *testing.T) {
 		{
 			// Send 100 integers,
 			// ensure that we receive them non-corrupted in FIFO order.
-			c := channel.NewChannelRef[uint64](chanCap)
+			c := NewChannelRef[uint64](chanCap)
 			go func() {
 				for i := uint64(0); i < 100; i++ {
 					c.Send(i)
@@ -160,7 +158,7 @@ func TestChan(t *testing.T) {
 					}
 				}()
 			}
-			done := channel.NewChannelRef[map[uint64]uint64](chanCap)
+			done := NewChannelRef[map[uint64]uint64](chanCap)
 			for p := uint64(0); p < P; p++ {
 				go func() {
 					recv := make(map[uint64]uint64)
@@ -190,7 +188,7 @@ func TestChan(t *testing.T) {
 
 		{
 			// Test len/cap.
-			c := channel.NewChannelRef[uint64](chanCap)
+			c := NewChannelRef[uint64](chanCap)
 			if c.Len() != uint64(0) || c.Cap() != chanCap {
 				t.Fatalf("chan[%d]: bad len/cap, expect %v/%v, got %v/%v", chanCap, 0, chanCap, c.Len(), c.Cap())
 			}
@@ -213,7 +211,7 @@ func TestLenCapComparedWithGoChannels(t *testing.T) {
 		t.Run(fmt.Sprintf("Capacity%d", capacity), func(t *testing.T) {
 			// Create both channel types
 			goChan := make(chan int, capacity)
-			ourChan := channel.NewChannelRef[int](capacity)
+			ourChan := NewChannelRef[int](capacity)
 
 			// Test initial state
 			goLen := len(goChan)
@@ -294,7 +292,7 @@ func TestLenCapComparedWithGoChannels(t *testing.T) {
 	// Test special case: nil channel
 	t.Run("NilChannel", func(t *testing.T) {
 		var goChan chan int
-		var ourChan *channel.Channel[int]
+		var ourChan *Channel[int]
 
 		goLen := len(goChan)
 		goCap := cap(goChan)
@@ -313,7 +311,7 @@ func TestBlockingBehavior(t *testing.T) {
 	timeout := time.Millisecond * 10 // Reasonable timeout to check blocking behavior
 
 	t.Run("ReceiveFromEmptyBlocks", func(t *testing.T) {
-		c := channel.NewChannelRef[int](0) // Unbuffered channel
+		c := NewChannelRef[int](0) // Unbuffered channel
 
 		done := make(chan bool)
 		go func() {
@@ -330,8 +328,8 @@ func TestBlockingBehavior(t *testing.T) {
 	})
 
 	t.Run("SendToFullBlocks", func(t *testing.T) {
-		c := channel.NewChannelRef[int](1) // Buffered channel with capacity 1
-		c.Send(42)                         // Fill the channel
+		c := NewChannelRef[int](1) // Buffered channel with capacity 1
+		c.Send(42)                 // Fill the channel
 
 		done := make(chan bool)
 		go func() {
@@ -362,7 +360,7 @@ func TestBlockingBehavior(t *testing.T) {
 		t.Run("SendToNilBlocks", func(t *testing.T) {
 			// Compare with Go's behavior
 			var goChan chan int
-			var ourChan *channel.Channel[int] = nil
+			var ourChan *Channel[int] = nil
 
 			goBlocked := true
 			ourBlocked := true
@@ -403,7 +401,7 @@ func TestBlockingBehavior(t *testing.T) {
 		t.Run("ReceiveFromNilBlocks", func(t *testing.T) {
 			// Compare with Go's behavior
 			var goChan chan int
-			var ourChan *channel.Channel[int] = nil
+			var ourChan *Channel[int] = nil
 
 			goBlocked := true
 			ourBlocked := true
@@ -466,7 +464,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		ourChan := channel.NewChannelRef[int](1)
+		ourChan := NewChannelRef[int](1)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.Send(42)
@@ -497,7 +495,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		ourChan := channel.NewChannelRef[int](1)
+		ourChan := NewChannelRef[int](1)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.Close()
@@ -533,7 +531,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		ourChan := channel.NewChannelRef[int](1)
+		ourChan := NewChannelRef[int](1)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.TrySend(42)
@@ -569,7 +567,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		ourChan := channel.NewChannelRef[int](5)
+		ourChan := NewChannelRef[int](5)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.TrySend(42)
@@ -599,7 +597,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		var ourChan *channel.Channel[int]
+		var ourChan *Channel[int]
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.Close()
 		})
@@ -626,7 +624,7 @@ func TestNonblockRecvRace(t *testing.T) {
 		n = 100
 	}
 	for i := uint64(0); i < n; i++ {
-		c := channel.NewChannelRef[uint64](1)
+		c := NewChannelRef[uint64](1)
 		c.Send(1)
 		go func() {
 			selected, _, _ := c.TryReceive()
@@ -647,8 +645,8 @@ func TestMultiConsumer(t *testing.T) {
 
 	pn := []uint64{2, 3, 7, 11, 13, 17, 19, 23, 27, 31}
 
-	q := channel.NewChannelRef[uint64](nwork * 3)
-	r := channel.NewChannelRef[uint64](nwork * 3)
+	q := NewChannelRef[uint64](nwork * 3)
+	r := NewChannelRef[uint64](nwork * 3)
 
 	// workers
 	var wg sync.WaitGroup
@@ -716,14 +714,14 @@ func doRequest(useSelect bool) (*response, error) {
 		resp *response
 		err  error
 	}
-	ch := channel.NewChannelRef[*async](0)
-	done := channel.NewChannelRef[struct{}](0)
+	ch := NewChannelRef[*async](0)
+	done := NewChannelRef[struct{}](0)
 
 	if useSelect {
 		go func() {
-			case_1 := channel.NewSendCase[*async](ch, &async{resp: nil, err: myError{}})
-			case_2 := channel.NewRecvCase[struct{}](done)
-			selected_case := channel.Select2(case_1, case_2, true)
+			case_1 := NewSendCase[*async](ch, &async{resp: nil, err: myError{}})
+			case_2 := NewRecvCase[struct{}](done)
+			selected_case := Select2(case_1, case_2, true)
 			// These cases don't actually do anything but wanted to stick with the intended
 			// translation throughout this file.
 			if selected_case == 0 {
@@ -797,15 +795,15 @@ func makeByte() []byte {
 // always receive from one or the other. It must never execute the default case.
 func TestNonblockSelectRace(t *testing.T) {
 	n := 1000
-	done := channel.NewChannelRef[bool](0)
+	done := NewChannelRef[bool](0)
 	for i := 0; i < n; i++ {
-		c1 := channel.NewChannelRef[int](1)
-		c2 := channel.NewChannelRef[int](1)
+		c1 := NewChannelRef[int](1)
+		c2 := NewChannelRef[int](1)
 		c1.Send(1)
 		go func() {
-			case_1 := channel.NewRecvCase(c1)
-			case_2 := channel.NewRecvCase(c2)
-			selected_case := channel.Select2(case_1, case_2, false)
+			case_1 := NewRecvCase(c1)
+			case_2 := NewRecvCase(c2)
+			selected_case := Select2(case_1, case_2, false)
 			if selected_case == 0 {
 			}
 			if selected_case == 1 {
@@ -829,15 +827,15 @@ func TestNonblockSelectRace(t *testing.T) {
 // Same as TestNonblockSelectRace, but close(c2) replaces c2 <- 1.
 func TestNonblockSelectRace2(t *testing.T) {
 	n := 1000
-	done := channel.NewChannelRef[bool](0)
+	done := NewChannelRef[bool](0)
 	for i := 0; i < n; i++ {
-		c1 := channel.NewChannelRef[int](1)
-		c2 := channel.NewChannelRef[int](1)
+		c1 := NewChannelRef[int](1)
+		c2 := NewChannelRef[int](1)
 		c1.Send(1)
 		go func() {
-			case_1 := channel.NewRecvCase(c1)
-			case_2 := channel.NewRecvCase(c2)
-			selected_case := channel.Select2(case_1, case_2, false)
+			case_1 := NewRecvCase(c1)
+			case_2 := NewRecvCase(c2)
+			selected_case := Select2(case_1, case_2, false)
 			if selected_case == 0 {
 			}
 			if selected_case == 1 {
@@ -867,16 +865,16 @@ func TestSelfSelect(t *testing.T) {
 	for _, chanCap := range []uint64{0, 10} {
 		var wg sync.WaitGroup
 		wg.Add(2)
-		c := channel.NewChannelRef[uint64](uint64(chanCap))
+		c := NewChannelRef[uint64](uint64(chanCap))
 		for p := uint64(0); p < 2; p++ {
 			p := p
 			go func() {
 				defer wg.Done()
 				for i := uint64(0); i < 1000; i++ {
 					if p == 0 || i%2 == 0 {
-						case_1 := channel.NewSendCase(c, p)
-						case_2 := channel.NewRecvCase(c)
-						selected_case := channel.Select2(case_1, case_2, true)
+						case_1 := NewSendCase(c, p)
+						case_2 := NewRecvCase(c)
+						selected_case := Select2(case_1, case_2, true)
 						if selected_case == 0 {
 							break
 						} else if selected_case == 1 {
@@ -887,9 +885,9 @@ func TestSelfSelect(t *testing.T) {
 							break
 						}
 					} else {
-						case_1 := channel.NewRecvCase(c)
-						case_2 := channel.NewSendCase(c, p)
-						selected_case := channel.Select2(case_1, case_2, true)
+						case_1 := NewRecvCase(c)
+						case_2 := NewSendCase(c, p)
+						selected_case := Select2(case_1, case_2, true)
 						if selected_case == 0 {
 							if chanCap == 0 && case_1.Value == p {
 								t.Errorf("self receive")
@@ -910,18 +908,18 @@ func TestSelfSelect(t *testing.T) {
 // Make sure that a "perpetually selectable" closed receive case appearing first does not mean
 // it will be selected every time.
 func TestSelectLivenessOrder1(t *testing.T) {
-	c1 := channel.NewChannelRef[uint64](uint64(0))
-	c2 := channel.NewChannelRef[uint64](uint64(2))
+	c1 := NewChannelRef[uint64](uint64(0))
+	c2 := NewChannelRef[uint64](uint64(2))
 	c1.Close()
 	c2.Send(0)
 
-	case_1 := channel.NewRecvCase(c1)
-	case_2 := channel.NewRecvCase(c2)
+	case_1 := NewRecvCase(c1)
+	case_2 := NewRecvCase(c2)
 
 	c1_selected := false
 	c2_selected := false
 	for {
-		selected_case := channel.Select2(case_1, case_2, false)
+		selected_case := Select2(case_1, case_2, false)
 		// Make sure we eventually hit the second case
 		if selected_case == 0 {
 			c1_selected = true
@@ -939,17 +937,17 @@ func TestSelectLivenessOrder1(t *testing.T) {
 // Same as above but swap the case order to make sure it works symmetrically i.e. the
 // implementation doesn't have the same problem in the opposite order.
 func TestSelectLivenessOrder2(t *testing.T) {
-	c1 := channel.NewChannelRef[uint64](uint64(0))
-	c2 := channel.NewChannelRef[uint64](uint64(1))
-	case_1 := channel.NewRecvCase(c1)
-	case_2 := channel.NewRecvCase(c2)
+	c1 := NewChannelRef[uint64](uint64(0))
+	c2 := NewChannelRef[uint64](uint64(1))
+	case_1 := NewRecvCase(c1)
+	case_2 := NewRecvCase(c2)
 
 	c1.Close()
 	c2.Send(0)
 	c1_selected := false
 	c2_selected := false
 	for {
-		selected_case := channel.Select2(case_2, case_1, false)
+		selected_case := Select2(case_2, case_1, false)
 		// Make sure we eventually hit the second case
 		if selected_case == 0 {
 			c1_selected = true
@@ -967,17 +965,17 @@ func TestSelectLivenessOrder2(t *testing.T) {
 // Make sure if we keep selecting and 1 case is immediately selectable we still can choose a case
 // that eventually becomes selectable.
 func TestSelectLivenessNotImmediatelySelectable(t *testing.T) {
-	c1 := channel.NewChannelRef[uint64](uint64(0))
-	c2 := channel.NewChannelRef[uint64](uint64(0))
-	case_1 := channel.NewRecvCase(c1)
-	case_2 := channel.NewRecvCase(c2)
+	c1 := NewChannelRef[uint64](uint64(0))
+	c2 := NewChannelRef[uint64](uint64(0))
+	case_1 := NewRecvCase(c1)
+	case_2 := NewRecvCase(c2)
 
 	c1.Close()
 	c1_selected := false
 	c2_selected := false
 	go func() {
 		for {
-			selected_case := channel.Select2(case_2, case_1, false)
+			selected_case := Select2(case_2, case_1, false)
 			// Make sure we eventually hit the second case
 			if selected_case == 0 {
 				c1_selected = true
@@ -998,18 +996,18 @@ func TestSelectLivenessNotImmediatelySelectable(t *testing.T) {
 // appears first
 func TestSelectFairnessWithBufferedChannel(t *testing.T) {
 	// Create one buffered and one unbuffered channel
-	c1 := channel.NewChannelRef[int](1) // Buffered (capacity 1)
-	c2 := channel.NewChannelRef[int](0) // Unbuffered
+	c1 := NewChannelRef[int](1) // Buffered (capacity 1)
+	c2 := NewChannelRef[int](0) // Unbuffered
 
 	// Create select cases - buffered channel first
-	case1 := channel.NewRecvCase(c1)
-	case2 := channel.NewRecvCase(c2)
+	case1 := NewRecvCase(c1)
+	case2 := NewRecvCase(c2)
 
 	// Put data in the buffered channel to make it immediately ready
 	c1.Send(42)
 
 	// Channel to signal test completion
-	done := channel.NewChannelRef[bool](0)
+	done := NewChannelRef[bool](0)
 
 	buffered_selected := false
 	unbuffered_selected := false
@@ -1017,7 +1015,7 @@ func TestSelectFairnessWithBufferedChannel(t *testing.T) {
 	// Start a goroutine that selects until both channels have been chosen
 	go func() {
 		for {
-			selected_case := channel.Select2(case1, case2, true)
+			selected_case := Select2(case1, case2, true)
 
 			if selected_case == 0 {
 				buffered_selected = true
@@ -1047,15 +1045,15 @@ func TestSelectFairnessWithBufferedChannel(t *testing.T) {
 }
 func TestSelect1(t *testing.T) {
 	// One buffered channel so we can preload it without blocking
-	c1 := channel.NewChannelRef[uint64](1) // capacity=1
+	c1 := NewChannelRef[uint64](1) // capacity=1
 	// preload c1
 	c1.Send(66)
 
 	// build the case (generic used explicitly)
-	case1 := channel.NewRecvCase(c1)
+	case1 := NewRecvCase(c1)
 
 	// non-blocking: should pick the first case (index 0)
-	selected := channel.Select1(case1, false)
+	selected := Select1(case1, false)
 	if !selected {
 		t.Error("expected selected")
 	}
@@ -1069,18 +1067,18 @@ func TestSelect1(t *testing.T) {
 	}
 
 	// Create a new empty channel for testing non-blocking behavior
-	emptyC1 := channel.NewChannelRef[uint64](1)
-	emptyCase1 := channel.NewRecvCase(emptyC1)
+	emptyC1 := NewChannelRef[uint64](1)
+	emptyCase1 := NewRecvCase(emptyC1)
 
 	// With blocking=false and no selectable statement, should return DefaultCase
-	selected = channel.Select1(emptyCase1, false)
+	selected = Select1(emptyCase1, false)
 	if selected {
 		t.Error("expected !selected when non-blocking with no available case")
 	}
 
 	// Close the channel and test receive on closed channel
 	emptyC1.Close()
-	selected = channel.Select1(emptyCase1, true)
+	selected = Select1(emptyCase1, true)
 	if !selected {
 		t.Error("expected selected for closed channel")
 	}
@@ -1094,17 +1092,17 @@ func TestSelect1(t *testing.T) {
 
 func TestSelect2(t *testing.T) {
 	// Two buffered channels so we can preload one without blocking
-	c1 := channel.NewChannelRef[uint64](1) // capacity=1
-	c2 := channel.NewChannelRef[uint64](1) // capacity=1
+	c1 := NewChannelRef[uint64](1) // capacity=1
+	c2 := NewChannelRef[uint64](1) // capacity=1
 	// preload c2
 	c2.Send(77)
 
 	// build the cases (generic used explicitly)
-	case1 := channel.NewRecvCase(c1)
-	case2 := channel.NewRecvCase(c2)
+	case1 := NewRecvCase(c1)
+	case2 := NewRecvCase(c2)
 
 	// non-blocking: should pick the second case (index 1)
-	idx := channel.Select2(case1, case2, false)
+	idx := Select2(case1, case2, false)
 	if idx != 1 {
 		t.Errorf("expected selected index=1, got %d", idx)
 	}
@@ -1118,20 +1116,20 @@ func TestSelect2(t *testing.T) {
 	}
 
 	// Create new empty channels for testing non-blocking behavior
-	emptyC1 := channel.NewChannelRef[uint64](1)
-	emptyC2 := channel.NewChannelRef[uint64](1)
-	emptyCase1 := channel.NewRecvCase(emptyC1)
-	emptyCase2 := channel.NewRecvCase(emptyC2)
+	emptyC1 := NewChannelRef[uint64](1)
+	emptyC2 := NewChannelRef[uint64](1)
+	emptyCase1 := NewRecvCase(emptyC1)
+	emptyCase2 := NewRecvCase(emptyC2)
 
 	// With blocking=false and no selectable statement, should return DefaultCase
-	idx = channel.Select2(emptyCase1, emptyCase2, false)
+	idx = Select2(emptyCase1, emptyCase2, false)
 	if idx != 2 {
 		t.Errorf("expected selected index=3 when non-blocking with no available case, got %d", idx)
 	}
 
 	// Close a channel and test receive on closed channel
 	emptyC1.Close()
-	idx = channel.Select2(emptyCase1, emptyCase2, true)
+	idx = Select2(emptyCase1, emptyCase2, true)
 	if idx != 0 {
 		t.Errorf("expected selected index=0 for closed channel, got %d", idx)
 	}
@@ -1145,19 +1143,19 @@ func TestSelect2(t *testing.T) {
 
 func TestSelect3(t *testing.T) {
 	// Three buffered channels so we can preload one without blocking
-	c1 := channel.NewChannelRef[uint64](1) // capacity=1
-	c2 := channel.NewChannelRef[uint64](1) // capacity=1
-	c3 := channel.NewChannelRef[uint64](1) // capacity=1
+	c1 := NewChannelRef[uint64](1) // capacity=1
+	c2 := NewChannelRef[uint64](1) // capacity=1
+	c3 := NewChannelRef[uint64](1) // capacity=1
 	// preload c3
 	c3.Send(88)
 
 	// build the cases (generic used explicitly)
-	case1 := channel.NewRecvCase(c1)
-	case2 := channel.NewRecvCase(c2)
-	case3 := channel.NewRecvCase(c3)
+	case1 := NewRecvCase(c1)
+	case2 := NewRecvCase(c2)
+	case3 := NewRecvCase(c3)
 
 	// non-blocking: should pick the third case (index 2)
-	idx := channel.Select3(case1, case2, case3, false)
+	idx := Select3(case1, case2, case3, false)
 	if idx != 2 {
 		t.Errorf("expected selected index=2, got %d", idx)
 	}
@@ -1171,22 +1169,22 @@ func TestSelect3(t *testing.T) {
 	}
 
 	// Create new empty channels for testing non-blocking behavior
-	emptyC1 := channel.NewChannelRef[uint64](1)
-	emptyC2 := channel.NewChannelRef[uint64](1)
-	emptyC3 := channel.NewChannelRef[uint64](1)
-	emptyCase1 := channel.NewRecvCase(emptyC1)
-	emptyCase2 := channel.NewRecvCase(emptyC2)
-	emptyCase3 := channel.NewRecvCase(emptyC3)
+	emptyC1 := NewChannelRef[uint64](1)
+	emptyC2 := NewChannelRef[uint64](1)
+	emptyC3 := NewChannelRef[uint64](1)
+	emptyCase1 := NewRecvCase(emptyC1)
+	emptyCase2 := NewRecvCase(emptyC2)
+	emptyCase3 := NewRecvCase(emptyC3)
 
 	// With blocking=false and no selectable statement, should return DefaultCase
-	idx = channel.Select3(emptyCase1, emptyCase2, emptyCase3, false)
+	idx = Select3(emptyCase1, emptyCase2, emptyCase3, false)
 	if idx != 3 {
 		t.Errorf("expected selected index=3 when non-blocking with no available case, got %d", idx)
 	}
 
 	// Close a channel and test receive on closed channel
 	emptyC2.Close()
-	idx = channel.Select3(emptyCase1, emptyCase2, emptyCase3, true)
+	idx = Select3(emptyCase1, emptyCase2, emptyCase3, true)
 	if idx != 1 {
 		t.Errorf("expected selected index=1 for closed channel, got %d", idx)
 	}
@@ -1200,21 +1198,21 @@ func TestSelect3(t *testing.T) {
 
 func TestSelect4(t *testing.T) {
 	// Four buffered channels so we can preload one without blocking
-	c1 := channel.NewChannelRef[uint64](1) // capacity=1
-	c2 := channel.NewChannelRef[uint64](1) // capacity=1
-	c3 := channel.NewChannelRef[uint64](1) // capacity=1
-	c4 := channel.NewChannelRef[uint64](1) // capacity=1
+	c1 := NewChannelRef[uint64](1) // capacity=1
+	c2 := NewChannelRef[uint64](1) // capacity=1
+	c3 := NewChannelRef[uint64](1) // capacity=1
+	c4 := NewChannelRef[uint64](1) // capacity=1
 	// preload c4
 	c4.Send(99)
 
 	// build the cases (generic used explicitly)
-	case1 := channel.NewRecvCase(c1)
-	case2 := channel.NewRecvCase(c2)
-	case3 := channel.NewRecvCase(c3)
-	case4 := channel.NewRecvCase(c4)
+	case1 := NewRecvCase(c1)
+	case2 := NewRecvCase(c2)
+	case3 := NewRecvCase(c3)
+	case4 := NewRecvCase(c4)
 
 	// non-blocking: should pick the fourth case (index 3)
-	idx := channel.Select4(case1, case2, case3, case4, false)
+	idx := Select4(case1, case2, case3, case4, false)
 	if idx != 3 {
 		t.Errorf("expected selected index=3, got %d", idx)
 	}
@@ -1228,24 +1226,24 @@ func TestSelect4(t *testing.T) {
 	}
 
 	// Create new empty channels for testing non-blocking behavior
-	emptyC1 := channel.NewChannelRef[uint64](1)
-	emptyC2 := channel.NewChannelRef[uint64](1)
-	emptyC3 := channel.NewChannelRef[uint64](1)
-	emptyC4 := channel.NewChannelRef[uint64](1)
-	emptyCase1 := channel.NewRecvCase(emptyC1)
-	emptyCase2 := channel.NewRecvCase(emptyC2)
-	emptyCase3 := channel.NewRecvCase(emptyC3)
-	emptyCase4 := channel.NewRecvCase(emptyC4)
+	emptyC1 := NewChannelRef[uint64](1)
+	emptyC2 := NewChannelRef[uint64](1)
+	emptyC3 := NewChannelRef[uint64](1)
+	emptyC4 := NewChannelRef[uint64](1)
+	emptyCase1 := NewRecvCase(emptyC1)
+	emptyCase2 := NewRecvCase(emptyC2)
+	emptyCase3 := NewRecvCase(emptyC3)
+	emptyCase4 := NewRecvCase(emptyC4)
 
 	// With blocking=false and no selectable statement, should return DefaultCase
-	idx = channel.Select4(emptyCase1, emptyCase2, emptyCase3, emptyCase4, false)
+	idx = Select4(emptyCase1, emptyCase2, emptyCase3, emptyCase4, false)
 	if idx != 4 {
 		t.Errorf("expected selected index=4 when non-blocking with no available case, got %d", idx)
 	}
 
 	// Close a channel and test receive on closed channel
 	emptyC3.Close()
-	idx = channel.Select4(emptyCase1, emptyCase2, emptyCase3, emptyCase4, true)
+	idx = Select4(emptyCase1, emptyCase2, emptyCase3, emptyCase4, true)
 	if idx != 2 {
 		t.Errorf("expected selected index=2 for closed channel, got %d", idx)
 	}
@@ -1259,23 +1257,23 @@ func TestSelect4(t *testing.T) {
 
 func TestSelect5(t *testing.T) {
 	// Five buffered channels so we can preload one without blocking
-	c1 := channel.NewChannelRef[uint64](1) // capacity=1
-	c2 := channel.NewChannelRef[uint64](1) // capacity=1
-	c3 := channel.NewChannelRef[uint64](1) // capacity=1
-	c4 := channel.NewChannelRef[uint64](1) // capacity=1
-	c5 := channel.NewChannelRef[uint64](1) // capacity=1
+	c1 := NewChannelRef[uint64](1) // capacity=1
+	c2 := NewChannelRef[uint64](1) // capacity=1
+	c3 := NewChannelRef[uint64](1) // capacity=1
+	c4 := NewChannelRef[uint64](1) // capacity=1
+	c5 := NewChannelRef[uint64](1) // capacity=1
 	// preload c5
 	c5.Send(111)
 
 	// build the cases (generic used explicitly)
-	case1 := channel.NewRecvCase(c1)
-	case2 := channel.NewRecvCase(c2)
-	case3 := channel.NewRecvCase(c3)
-	case4 := channel.NewRecvCase(c4)
-	case5 := channel.NewRecvCase(c5)
+	case1 := NewRecvCase(c1)
+	case2 := NewRecvCase(c2)
+	case3 := NewRecvCase(c3)
+	case4 := NewRecvCase(c4)
+	case5 := NewRecvCase(c5)
 
 	// non-blocking: should pick the fifth case (index 4)
-	idx := channel.Select5(case1, case2, case3, case4, case5, false)
+	idx := Select5(case1, case2, case3, case4, case5, false)
 	if idx != 4 {
 		t.Errorf("expected selected index=4, got %d", idx)
 	}
@@ -1289,26 +1287,26 @@ func TestSelect5(t *testing.T) {
 	}
 
 	// Create new empty channels for testing non-blocking behavior
-	emptyC1 := channel.NewChannelRef[uint64](1)
-	emptyC2 := channel.NewChannelRef[uint64](1)
-	emptyC3 := channel.NewChannelRef[uint64](1)
-	emptyC4 := channel.NewChannelRef[uint64](1)
-	emptyC5 := channel.NewChannelRef[uint64](1)
-	emptyCase1 := channel.NewRecvCase(emptyC1)
-	emptyCase2 := channel.NewRecvCase(emptyC2)
-	emptyCase3 := channel.NewRecvCase(emptyC3)
-	emptyCase4 := channel.NewRecvCase(emptyC4)
-	emptyCase5 := channel.NewRecvCase(emptyC5)
+	emptyC1 := NewChannelRef[uint64](1)
+	emptyC2 := NewChannelRef[uint64](1)
+	emptyC3 := NewChannelRef[uint64](1)
+	emptyC4 := NewChannelRef[uint64](1)
+	emptyC5 := NewChannelRef[uint64](1)
+	emptyCase1 := NewRecvCase(emptyC1)
+	emptyCase2 := NewRecvCase(emptyC2)
+	emptyCase3 := NewRecvCase(emptyC3)
+	emptyCase4 := NewRecvCase(emptyC4)
+	emptyCase5 := NewRecvCase(emptyC5)
 
 	// With blocking=false and no selectable statement, should return DefaultCase
-	idx = channel.Select5(emptyCase1, emptyCase2, emptyCase3, emptyCase4, emptyCase5, false)
+	idx = Select5(emptyCase1, emptyCase2, emptyCase3, emptyCase4, emptyCase5, false)
 	if idx != 5 {
 		t.Errorf("expected selected index=5 when non-blocking with no available case, got %d", idx)
 	}
 
 	// Close a channel and test receive on closed channel
 	emptyC4.Close()
-	idx = channel.Select5(emptyCase1, emptyCase2, emptyCase3, emptyCase4, emptyCase5, true)
+	idx = Select5(emptyCase1, emptyCase2, emptyCase3, emptyCase4, emptyCase5, true)
 	if idx != 3 {
 		t.Errorf("expected selected index=3 for closed channel, got %d", idx)
 	}

--- a/model/test/channel_test.go
+++ b/model/test/channel_test.go
@@ -1,0 +1,1321 @@
+package chan_test
+
+/*
+Tests to demonstrate Go's behavior on various subtle examples.
+*/
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/goose-lang/goose/model/channel"
+)
+
+// The channel tests below are for the Goose model of channels that is implemented as a Go
+// struct. The tests are hand translated versions of correctness based tests in
+// https://go.dev/src/runtime/chan_test.go https://go.dev/src/runtime/chanbarrier_test.go
+func TestChan(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(4))
+	var N uint64 = 200
+	if testing.Short() {
+		N = 20
+	}
+	for chanCap := uint64(0); chanCap < N; chanCap++ {
+		{
+			// Ensure that receive from empty chan blocks.
+			c := channel.NewChannelRef[uint64](chanCap)
+			recv1 := false
+			go func() {
+				_, _ = c.Receive()
+				recv1 = true
+			}()
+			recv2 := false
+			go func() {
+				_, _ = c.Receive()
+				recv2 = true
+			}()
+			time.Sleep(time.Millisecond)
+			if recv1 || recv2 {
+				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
+			}
+			// Ensure that non-blocking receive does not block.
+
+			selected, _, _ := c.TryReceive()
+			if selected {
+				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
+			}
+
+			selected, _, _ = c.TryReceive()
+			if selected {
+				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
+			}
+			c.Send(0)
+			c.Send(0)
+		}
+
+		{
+			// Ensure that send to full chan blocks.
+			c := channel.NewChannelRef[uint64](chanCap)
+			for i := uint64(0); i < chanCap; i++ {
+				c.Send(i)
+			}
+			sent := uint32(0)
+			go func() {
+				c.Send(0)
+				atomic.StoreUint32(&sent, 1)
+			}()
+			time.Sleep(time.Millisecond)
+			if atomic.LoadUint32(&sent) != 0 {
+				t.Fatalf("chan[%d]: send to full chan", chanCap)
+			}
+			selected := c.TrySend(0)
+			if selected {
+				t.Fatalf("chan[%d]: send to full chan", chanCap)
+			}
+			c.Receive()
+		}
+
+		{
+			// Ensure that we receive 0 from closed chan.
+			c := channel.NewChannelRef[uint64](chanCap)
+			for i := uint64(0); i < chanCap; i++ {
+				c.Send(i)
+			}
+			c.Close()
+			for i := uint64(0); i < chanCap; i++ {
+				v, _ := c.Receive()
+				if v != i {
+					t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, i)
+				}
+			}
+			if v, _ := c.Receive(); v != 0 {
+				t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, 0)
+			}
+			if v, ok := c.Receive(); v != 0 || ok {
+				t.Fatalf("chan[%d]: received %v/%v, expected %v/%v", chanCap, v, ok, 0, false)
+			}
+		}
+
+		{
+			// Ensure that close unblocks receive.
+			c := channel.NewChannelRef[uint64](chanCap)
+			done := channel.NewChannelRef[bool](0)
+			go func() {
+				v, ok := c.Receive()
+				done.Send(v == 0 && ok == false)
+			}()
+			time.Sleep(time.Millisecond)
+			c.Close()
+			actually_done, _ := done.Receive()
+			if !actually_done {
+				t.Fatalf("chan[%d]: received non zero from closed chan", chanCap)
+			}
+		}
+
+		{
+			// Send 100 integers,
+			// ensure that we receive them non-corrupted in FIFO order.
+			c := channel.NewChannelRef[uint64](chanCap)
+			go func() {
+				for i := uint64(0); i < 100; i++ {
+					c.Send(i)
+				}
+			}()
+			for i := uint64(0); i < 100; i++ {
+				v, _ := c.Receive()
+				if v != i {
+					t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, i)
+				}
+			}
+
+			// Same, but using recv2.
+			go func() {
+				for i := uint64(0); i < 100; i++ {
+					c.Send(i)
+				}
+			}()
+			for i := uint64(0); i < 100; i++ {
+				v, ok := c.Receive()
+				if !ok {
+					t.Fatalf("chan[%d]: receive failed, expected %v", chanCap, i)
+				}
+				if v != i {
+					t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, i)
+				}
+			}
+
+			// Send 1000 integers in 4 goroutines,
+			// ensure that we receive what we send.
+			const P = 4
+			const L uint64 = 1000
+			for p := 0; p < P; p++ {
+				go func() {
+					for i := uint64(0); i < L; i++ {
+						c.Send(i)
+					}
+				}()
+			}
+			done := channel.NewChannelRef[map[uint64]uint64](chanCap)
+			for p := uint64(0); p < P; p++ {
+				go func() {
+					recv := make(map[uint64]uint64)
+					for i := uint64(0); i < L; i++ {
+						v, _ := c.Receive()
+						recv[v] = recv[v] + 1
+					}
+					done.Send(recv)
+				}()
+			}
+			recv := make(map[uint64]uint64)
+			for p := uint64(0); p < P; p++ {
+				received_val, _ := done.Receive()
+				for k, v := range received_val {
+					recv[k] = recv[k] + v
+				}
+			}
+			if uint64(len(recv)) != L {
+				t.Fatalf("chan[%d]: received %v values, expected %v", chanCap, len(recv), L)
+			}
+			for _, v := range recv {
+				if v != P {
+					t.Fatalf("chan[%d]: received %v values, expected %v", chanCap, v, P)
+				}
+			}
+		}
+
+		{
+			// Test len/cap.
+			c := channel.NewChannelRef[uint64](chanCap)
+			if c.Len() != uint64(0) || c.Cap() != chanCap {
+				t.Fatalf("chan[%d]: bad len/cap, expect %v/%v, got %v/%v", chanCap, 0, chanCap, c.Len(), c.Cap())
+			}
+			for i := uint64(0); i < chanCap; i++ {
+				c.Send(i)
+			}
+			if c.Len() != chanCap || c.Cap() != chanCap {
+				t.Fatalf("chan[%d]: bad len/cap, expect %v/%v, got %v/%v", chanCap, chanCap, chanCap, c.Len(), c.Cap())
+			}
+		}
+	}
+}
+
+// This just makes sure that we have the same semantics for len and cap. I don't
+// think we plan on doing much with these, but if we do, might as well get it right
+func TestLenCapComparedWithGoChannels(t *testing.T) {
+	capacities := []uint64{0, 1, 2, 5, 10}
+
+	for _, capacity := range capacities {
+		t.Run(fmt.Sprintf("Capacity%d", capacity), func(t *testing.T) {
+			// Create both channel types
+			goChan := make(chan int, capacity)
+			ourChan := channel.NewChannelRef[int](capacity)
+
+			// Test initial state
+			goLen := len(goChan)
+			goCap := cap(goChan)
+			ourLen := int(ourChan.Len())
+			ourCap := int(ourChan.Cap())
+
+			if goLen != ourLen || goCap != ourCap {
+				t.Errorf("Initial state mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+					goLen, goCap, ourLen, ourCap)
+			}
+
+			// Test after adding items
+			itemsToAdd := capacity
+			if capacity == 0 {
+				itemsToAdd = 0
+			} else {
+				for i := uint64(0); i < capacity; i++ {
+					goChan <- int(i)
+					ourChan.Send(int(i))
+				}
+
+				goLen = len(goChan)
+				goCap = cap(goChan)
+				ourLen = int(ourChan.Len())
+				ourCap = int(ourChan.Cap())
+
+				if goLen != ourLen || goCap != ourCap {
+					t.Errorf("After filling mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+						goLen, goCap, ourLen, ourCap)
+				}
+			}
+
+			// Test after removing half the items
+			if itemsToAdd > 0 {
+				itemsToRemove := itemsToAdd / 2
+				for i := uint64(0); i < itemsToRemove; i++ {
+					<-goChan
+					ourChan.Receive()
+				}
+
+				goLen = len(goChan)
+				goCap = cap(goChan)
+				ourLen = int(ourChan.Len())
+				ourCap = int(ourChan.Cap())
+
+				if goLen != ourLen || goCap != ourCap {
+					t.Errorf("After partial removal mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+						goLen, goCap, ourLen, ourCap)
+				}
+			}
+
+			// Test after closing
+			// Need to drain remaining items first to compare fairly
+			if itemsToAdd > 0 {
+				remainingItems := itemsToAdd - (itemsToAdd / 2)
+				for i := uint64(0); i < remainingItems; i++ {
+					<-goChan
+					ourChan.Receive()
+				}
+			}
+
+			close(goChan)
+			ourChan.Close()
+
+			goLen = len(goChan)
+			goCap = cap(goChan)
+			ourLen = int(ourChan.Len())
+			ourCap = int(ourChan.Cap())
+
+			if goLen != ourLen || goCap != ourCap {
+				t.Errorf("After closing mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+					goLen, goCap, ourLen, ourCap)
+			}
+		})
+	}
+
+	// Test special case: nil channel
+	t.Run("NilChannel", func(t *testing.T) {
+		var goChan chan int
+		var ourChan *channel.Channel[int]
+
+		goLen := len(goChan)
+		goCap := cap(goChan)
+		ourLen := int(ourChan.Len()) // Should return 0 for nil channel
+		ourCap := int(ourChan.Cap()) // Should return 0 for nil channel
+
+		if goLen != ourLen || goCap != ourCap {
+			t.Errorf("Nil channel mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+				goLen, goCap, ourLen, ourCap)
+		}
+	})
+}
+
+// Some extra dummy checks for blocking behavior. Nil blocking is checked as well
+func TestBlockingBehavior(t *testing.T) {
+	timeout := time.Millisecond * 10 // Reasonable timeout to check blocking behavior
+
+	t.Run("ReceiveFromEmptyBlocks", func(t *testing.T) {
+		c := channel.NewChannelRef[int](0) // Unbuffered channel
+
+		done := make(chan bool)
+		go func() {
+			_, _ = c.Receive() // This should block
+			done <- true
+		}()
+
+		select {
+		case <-done:
+			t.Error("Receive from empty channel didn't block as expected")
+		case <-time.After(timeout):
+			// If we reach here, the operation blocked as expected
+		}
+	})
+
+	t.Run("SendToFullBlocks", func(t *testing.T) {
+		c := channel.NewChannelRef[int](1) // Buffered channel with capacity 1
+		c.Send(42)                         // Fill the channel
+
+		done := make(chan bool)
+		go func() {
+			c.Send(43) // This should block
+			done <- true
+		}()
+
+		select {
+		case <-done:
+			t.Error("Send to full channel didn't block as expected")
+		case <-time.After(timeout):
+			// If we reach here, the operation blocked as expected
+		}
+
+		// Clean up
+		_, _ = c.Receive()
+		select {
+		case <-done:
+			// Expected - operation completes
+		case <-time.After(timeout):
+			t.Error("Send operation didn't complete after space became available")
+		}
+	})
+
+	// Test nil channel behavior
+	t.Run("NilChannelBlocks", func(t *testing.T) {
+		// Test nil channel send
+		t.Run("SendToNilBlocks", func(t *testing.T) {
+			// Compare with Go's behavior
+			var goChan chan int
+			var ourChan *channel.Channel[int] = nil
+
+			goBlocked := true
+			ourBlocked := true
+
+			// Test Go's behavior
+			goBlockDone := make(chan bool)
+			go func() {
+				goChan <- 42 // This should block
+				goBlockDone <- true
+			}()
+
+			// Test our implementation
+			ourBlockDone := make(chan bool)
+			go func() {
+				ourChan.Send(42) // This should block
+				ourBlockDone <- true
+			}()
+
+			// Check if both operations block
+			select {
+			case <-goBlockDone:
+				goBlocked = false
+				t.Error("Go's send to nil channel didn't block as expected")
+			case <-ourBlockDone:
+				ourBlocked = false
+				t.Error("Our send to nil channel didn't block as expected")
+			case <-time.After(timeout):
+				// Both blocked, which is expected
+			}
+
+			if !goBlocked || !ourBlocked {
+				t.Errorf("Nil channel send blocking behavior mismatch: Go blocked: %v, Our blocked: %v",
+					goBlocked, ourBlocked)
+			}
+		})
+
+		// Test nil channel receive
+		t.Run("ReceiveFromNilBlocks", func(t *testing.T) {
+			// Compare with Go's behavior
+			var goChan chan int
+			var ourChan *channel.Channel[int] = nil
+
+			goBlocked := true
+			ourBlocked := true
+
+			// Test Go's behavior
+			goBlockDone := make(chan bool)
+			go func() {
+				_ = <-goChan // This should block
+				goBlockDone <- true
+			}()
+
+			// Test our implementation
+			ourBlockDone := make(chan bool)
+			go func() {
+				_, _ = ourChan.Receive() // This should block
+				ourBlockDone <- true
+			}()
+
+			// Check if both operations block
+			select {
+			case <-goBlockDone:
+				goBlocked = false
+				t.Error("Go's receive from nil channel didn't block as expected")
+			case <-ourBlockDone:
+				ourBlocked = false
+				t.Error("Our receive from nil channel didn't block as expected")
+			case <-time.After(timeout):
+				// Both blocked, which is expected
+			}
+
+			if !goBlocked || !ourBlocked {
+				t.Errorf("Nil channel receive blocking behavior mismatch: Go blocked: %v, Our blocked: %v",
+					goBlocked, ourBlocked)
+			}
+		})
+	})
+}
+
+// Make sure the panic situations lead to panic in the model with the same message.
+func TestPanicComparedWithGoChannels(t *testing.T) {
+	// Helper function to check if an operation panics and capture the panic message
+	assertPanicsWithMessage := func(f func()) (didPanic bool, message string) {
+		defer func() {
+			if r := recover(); r != nil {
+				didPanic = true
+				message = fmt.Sprint(r)
+			}
+		}()
+		f()
+		return false, ""
+	}
+
+	// Test send on closed channel
+	t.Run("SendOnClosedChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		goChan := make(chan int, 1)
+		close(goChan)
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			goChan <- 42
+		})
+
+		// Test with our channel implementation
+		ourChan := channel.NewChannelRef[int](1)
+		ourChan.Close()
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.Send(42)
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "send on closed channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+
+	// Test close on closed channel
+	t.Run("CloseOnClosedChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		goChan := make(chan int, 1)
+		close(goChan)
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			close(goChan)
+		})
+
+		// Test with our channel implementation
+		ourChan := channel.NewChannelRef[int](1)
+		ourChan.Close()
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.Close()
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "close of closed channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+
+	// Test try-send on closed channel (using select with default for Go)
+	t.Run("TrySendOnClosedChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		goChan := make(chan int, 1)
+		close(goChan)
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			select {
+			case goChan <- 42:
+				// Should panic before reaching here
+			default:
+				// Should panic before reaching here
+			}
+		})
+
+		// Test with our channel implementation
+		ourChan := channel.NewChannelRef[int](1)
+		ourChan.Close()
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.TrySend(42)
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "send on closed channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+
+	// Test buffered try-send on closed channel
+	t.Run("BufferedTrySendOnClosedChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		goChan := make(chan int, 5)
+		close(goChan)
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			select {
+			case goChan <- 42:
+				// Should panic before reaching here
+			default:
+				// Should panic before reaching here
+			}
+		})
+
+		// Test with our channel implementation
+		ourChan := channel.NewChannelRef[int](5)
+		ourChan.Close()
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.TrySend(42)
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "send on closed channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+
+	// Test close of nil channel
+	t.Run("CloseNilChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		var goChan chan int
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			close(goChan)
+		})
+
+		// Test with our channel implementation
+		var ourChan *channel.Channel[int]
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.Close()
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "close of nil channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+}
+
+func TestNonblockRecvRace(t *testing.T) {
+	var n uint64 = 10000
+	if testing.Short() {
+		n = 100
+	}
+	for i := uint64(0); i < n; i++ {
+		c := channel.NewChannelRef[uint64](1)
+		c.Send(1)
+		go func() {
+			selected, _, _ := c.TryReceive()
+			if !selected {
+				t.Error("chan is not ready")
+			}
+		}()
+		c.Close()
+		c.Receive()
+		if t.Failed() {
+			return
+		}
+	}
+}
+func TestMultiConsumer(t *testing.T) {
+	const nwork uint64 = 23
+	const niter uint64 = 271828
+
+	pn := []uint64{2, 3, 7, 11, 13, 17, 19, 23, 27, 31}
+
+	q := channel.NewChannelRef[uint64](nwork * 3)
+	r := channel.NewChannelRef[uint64](nwork * 3)
+
+	// workers
+	var wg sync.WaitGroup
+	for i := uint64(0); i < nwork; i++ {
+		wg.Add(1)
+		go func(w uint64) {
+			for {
+				selected, val, ok := q.TryReceive()
+				if !ok {
+					break
+				}
+				if selected {
+					if pn[w%uint64(len(pn))] == val {
+						runtime.Gosched()
+					}
+					r.Send(val)
+				}
+			}
+			wg.Done()
+		}(i)
+	}
+
+	// feeder & closer
+	var expect uint64 = 0
+	go func() {
+		for i := uint64(0); i < niter; i++ {
+			v := pn[i%uint64(len(pn))]
+			expect += v
+			q.Send(v)
+		}
+		q.Close() // no more work
+		wg.Wait() // workers done
+		r.Close() // ... so there can be no more results
+	}()
+
+	// consume & check
+	var n uint64 = 0
+	var s uint64 = 0
+	for {
+		selected, val, ok := r.TryReceive()
+		if !ok {
+			break
+		}
+		if selected {
+			n++
+			s += val
+		}
+	}
+	if n != niter || s != expect {
+		t.Errorf("Expected sum %d (got %d) from %d iter (saw %d)",
+			expect, s, niter, n)
+	}
+}
+
+type response struct {
+}
+
+type myError struct {
+}
+
+func (myError) Error() string { return "" }
+
+func doRequest(useSelect bool) (*response, error) {
+	type async struct {
+		resp *response
+		err  error
+	}
+	ch := channel.NewChannelRef[*async](0)
+	done := channel.NewChannelRef[struct{}](0)
+
+	if useSelect {
+		go func() {
+			case_1 := channel.NewSendCase[*async](ch, &async{resp: nil, err: myError{}})
+			case_2 := channel.NewRecvCase[struct{}](done)
+			selected_case := channel.Select2(case_1, case_2, true)
+			// These cases don't actually do anything but wanted to stick with the intended
+			// translation throughout this file.
+			if selected_case == 0 {
+
+			} else if selected_case == 1 {
+
+			}
+		}()
+	} else {
+		go func() {
+			ch.Send(&async{resp: nil, err: myError{}})
+		}()
+	}
+
+	var r *async = ch.ReceiveDiscardOk()
+	runtime.Gosched()
+	return r.resp, r.err
+}
+
+func TestChanSendSelectBarrier(t *testing.T) {
+	t.Parallel()
+	testChanSendBarrier(true)
+}
+
+func TestChanSendBarrier(t *testing.T) {
+	t.Parallel()
+	testChanSendBarrier(false)
+}
+
+func testChanSendBarrier(useSelect bool) {
+	var wg sync.WaitGroup
+	outer := 2
+	inner := 20
+	for i := 0; i < outer; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var garbage []byte
+			for j := 0; j < inner; j++ {
+				_, err := doRequest(useSelect)
+				_, ok := err.(myError)
+				if !ok {
+					panic(1)
+				}
+				garbage = makeByte()
+			}
+			_ = garbage
+		}()
+	}
+	wg.Wait()
+}
+
+//go:noinline
+func makeByte() []byte {
+	return make([]byte, 1<<10)
+}
+
+// This test checks that select acts on the state of the channels at one
+// moment in the execution, not over a smeared time window.
+// In the test, one goroutine does:
+//
+//	create c1, c2
+//	make c1 ready for receiving
+//	create second goroutine
+//	make c2 ready for receiving
+//	make c1 no longer ready for receiving (if possible)
+//
+// The second goroutine does a non-blocking select receiving from c1 and c2.
+// From the time the second goroutine is created, at least one of c1 and c2
+// is always ready for receiving, so the select in the second goroutine must
+// always receive from one or the other. It must never execute the default case.
+func TestNonblockSelectRace(t *testing.T) {
+	n := 1000
+	done := channel.NewChannelRef[bool](0)
+	for i := 0; i < n; i++ {
+		c1 := channel.NewChannelRef[int](1)
+		c2 := channel.NewChannelRef[int](1)
+		c1.Send(1)
+		go func() {
+			case_1 := channel.NewRecvCase(c1)
+			case_2 := channel.NewRecvCase(c2)
+			selected_case := channel.Select2(case_1, case_2, false)
+			if selected_case == 0 {
+			}
+			if selected_case == 1 {
+
+			}
+			if selected_case == 2 {
+				done.Send(false)
+				return
+			}
+			done.Send(true)
+		}()
+		c2.Send(1)
+		c1.TryReceive()
+		val := done.ReceiveDiscardOk()
+		if !val {
+			t.Fatal("no chan is ready")
+		}
+	}
+}
+
+// Same as TestNonblockSelectRace, but close(c2) replaces c2 <- 1.
+func TestNonblockSelectRace2(t *testing.T) {
+	n := 1000
+	done := channel.NewChannelRef[bool](0)
+	for i := 0; i < n; i++ {
+		c1 := channel.NewChannelRef[int](1)
+		c2 := channel.NewChannelRef[int](1)
+		c1.Send(1)
+		go func() {
+			case_1 := channel.NewRecvCase(c1)
+			case_2 := channel.NewRecvCase(c2)
+			selected_case := channel.Select2(case_1, case_2, false)
+			if selected_case == 0 {
+			}
+			if selected_case == 1 {
+
+			}
+			if selected_case == 2 {
+				done.Send(false)
+				return
+			}
+			done.Send(true)
+		}()
+		c2.Close()
+		c1.TryReceive()
+		val := done.ReceiveDiscardOk()
+		if !val {
+			t.Fatal("no chan is ready")
+		}
+	}
+}
+
+// Make sure that we can handle blocking select statements with matching send/receive
+// operations.
+func TestSelfSelect(t *testing.T) {
+	// Ensure that send/recv on the same chan in select
+	// does not crash nor deadlock.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
+	for _, chanCap := range []uint64{0, 10} {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		c := channel.NewChannelRef[uint64](uint64(chanCap))
+		for p := uint64(0); p < 2; p++ {
+			p := p
+			go func() {
+				defer wg.Done()
+				for i := uint64(0); i < 1000; i++ {
+					if p == 0 || i%2 == 0 {
+						case_1 := channel.NewSendCase(c, p)
+						case_2 := channel.NewRecvCase(c)
+						selected_case := channel.Select2(case_1, case_2, true)
+						if selected_case == 0 {
+							break
+						} else if selected_case == 1 {
+							if chanCap == 0 && case_2.Value == p {
+								t.Errorf("self receive")
+								return
+							}
+							break
+						}
+					} else {
+						case_1 := channel.NewRecvCase(c)
+						case_2 := channel.NewSendCase(c, p)
+						selected_case := channel.Select2(case_1, case_2, true)
+						if selected_case == 0 {
+							if chanCap == 0 && case_1.Value == p {
+								t.Errorf("self receive")
+								return
+							}
+							break
+						} else if selected_case == 1 {
+							break
+						}
+					}
+				}
+			}()
+		}
+		wg.Wait()
+	}
+}
+
+// Make sure that a "perpetually selectable" closed receive case appearing first does not mean
+// it will be selected every time.
+func TestSelectLivenessOrder1(t *testing.T) {
+	c1 := channel.NewChannelRef[uint64](uint64(0))
+	c2 := channel.NewChannelRef[uint64](uint64(2))
+	c1.Close()
+	c2.Send(0)
+
+	case_1 := channel.NewRecvCase(c1)
+	case_2 := channel.NewRecvCase(c2)
+
+	c1_selected := false
+	c2_selected := false
+	for {
+		selected_case := channel.Select2(case_1, case_2, false)
+		// Make sure we eventually hit the second case
+		if selected_case == 0 {
+			c1_selected = true
+		} else if selected_case == 1 {
+			c2_selected = true
+		}
+		if c1_selected && c2_selected {
+			break
+		}
+
+	}
+
+}
+
+// Same as above but swap the case order to make sure it works symmetrically i.e. the
+// implementation doesn't have the same problem in the opposite order.
+func TestSelectLivenessOrder2(t *testing.T) {
+	c1 := channel.NewChannelRef[uint64](uint64(0))
+	c2 := channel.NewChannelRef[uint64](uint64(1))
+	case_1 := channel.NewRecvCase(c1)
+	case_2 := channel.NewRecvCase(c2)
+
+	c1.Close()
+	c2.Send(0)
+	c1_selected := false
+	c2_selected := false
+	for {
+		selected_case := channel.Select2(case_2, case_1, false)
+		// Make sure we eventually hit the second case
+		if selected_case == 0 {
+			c1_selected = true
+		} else if selected_case == 1 {
+			c2_selected = true
+		}
+		if c1_selected && c2_selected {
+			break
+		}
+
+	}
+
+}
+
+// Make sure if we keep selecting and 1 case is immediately selectable we still can choose a case
+// that eventually becomes selectable.
+func TestSelectLivenessNotImmediatelySelectable(t *testing.T) {
+	c1 := channel.NewChannelRef[uint64](uint64(0))
+	c2 := channel.NewChannelRef[uint64](uint64(0))
+	case_1 := channel.NewRecvCase(c1)
+	case_2 := channel.NewRecvCase(c2)
+
+	c1.Close()
+	c1_selected := false
+	c2_selected := false
+	go func() {
+		for {
+			selected_case := channel.Select2(case_2, case_1, false)
+			// Make sure we eventually hit the second case
+			if selected_case == 0 {
+				c1_selected = true
+			} else if selected_case == 1 {
+				c2_selected = true
+			}
+			if c1_selected && c2_selected {
+				break
+			}
+		}
+	}()
+	time.Sleep(time.Millisecond * 10)
+	c2.Send(0)
+
+}
+
+// Make sure a selectable buffered channel case isn't selected every time if it
+// appears first
+func TestSelectFairnessWithBufferedChannel(t *testing.T) {
+	// Create one buffered and one unbuffered channel
+	c1 := channel.NewChannelRef[int](1) // Buffered (capacity 1)
+	c2 := channel.NewChannelRef[int](0) // Unbuffered
+
+	// Create select cases - buffered channel first
+	case1 := channel.NewRecvCase(c1)
+	case2 := channel.NewRecvCase(c2)
+
+	// Put data in the buffered channel to make it immediately ready
+	c1.Send(42)
+
+	// Channel to signal test completion
+	done := channel.NewChannelRef[bool](0)
+
+	buffered_selected := false
+	unbuffered_selected := false
+
+	// Start a goroutine that selects until both channels have been chosen
+	go func() {
+		for {
+			selected_case := channel.Select2(case1, case2, true)
+
+			if selected_case == 0 {
+				buffered_selected = true
+				// Refill the buffered channel
+				c1.Send(42)
+			} else if selected_case == 1 {
+				unbuffered_selected = true
+			}
+
+			if buffered_selected && unbuffered_selected {
+				done.Send(true)
+				return
+			}
+		}
+	}()
+
+	// Send to the unbuffered channel
+	c2.Send(99)
+
+	// Wait for the test to complete
+	result := done.ReceiveDiscardOk()
+
+	// The done channel will only receive a value if both channels were selected
+	if !result {
+		t.Fatal("Test did not complete successfully")
+	}
+}
+func TestSelect1(t *testing.T) {
+	// One buffered channel so we can preload it without blocking
+	c1 := channel.NewChannelRef[uint64](1) // capacity=1
+	// preload c1
+	c1.Send(66)
+
+	// build the case (generic used explicitly)
+	case1 := channel.NewRecvCase(c1)
+
+	// non-blocking: should pick the first case (index 0)
+	selected := channel.Select1(case1, false)
+	if !selected {
+		t.Error("expected selected")
+	}
+
+	// and confirm the SelectCase struct was populated
+	if case1.Value != 66 {
+		t.Errorf("expected case1.Value=66, got %v", case1.Value)
+	}
+	if !case1.Ok {
+		t.Error("expected case1.Ok=true, got false")
+	}
+
+	// Create a new empty channel for testing non-blocking behavior
+	emptyC1 := channel.NewChannelRef[uint64](1)
+	emptyCase1 := channel.NewRecvCase(emptyC1)
+
+	// With blocking=false and no selectable statement, should return DefaultCase
+	selected = channel.Select1(emptyCase1, false)
+	if selected {
+		t.Error("expected !selected when non-blocking with no available case")
+	}
+
+	// Close the channel and test receive on closed channel
+	emptyC1.Close()
+	selected = channel.Select1(emptyCase1, true)
+	if !selected {
+		t.Error("expected selected for closed channel")
+	}
+	if emptyCase1.Ok {
+		t.Error("expected emptyCase1.Ok=false for closed channel, got true")
+	}
+	if emptyCase1.Value != 0 {
+		t.Errorf("expected emptyCase1.Value=0 (zero value) for closed channel, got %v", emptyCase1.Value)
+	}
+}
+
+func TestSelect2(t *testing.T) {
+	// Two buffered channels so we can preload one without blocking
+	c1 := channel.NewChannelRef[uint64](1) // capacity=1
+	c2 := channel.NewChannelRef[uint64](1) // capacity=1
+	// preload c2
+	c2.Send(77)
+
+	// build the cases (generic used explicitly)
+	case1 := channel.NewRecvCase(c1)
+	case2 := channel.NewRecvCase(c2)
+
+	// non-blocking: should pick the second case (index 1)
+	idx := channel.Select2(case1, case2, false)
+	if idx != 1 {
+		t.Errorf("expected selected index=1, got %d", idx)
+	}
+
+	// and confirm the SelectCase struct was populated
+	if case2.Value != 77 {
+		t.Errorf("expected case2.Value=77, got %v", case2.Value)
+	}
+	if !case2.Ok {
+		t.Error("expected case2.Ok=true, got false")
+	}
+
+	// Create new empty channels for testing non-blocking behavior
+	emptyC1 := channel.NewChannelRef[uint64](1)
+	emptyC2 := channel.NewChannelRef[uint64](1)
+	emptyCase1 := channel.NewRecvCase(emptyC1)
+	emptyCase2 := channel.NewRecvCase(emptyC2)
+
+	// With blocking=false and no selectable statement, should return DefaultCase
+	idx = channel.Select2(emptyCase1, emptyCase2, false)
+	if idx != 2 {
+		t.Errorf("expected selected index=3 when non-blocking with no available case, got %d", idx)
+	}
+
+	// Close a channel and test receive on closed channel
+	emptyC1.Close()
+	idx = channel.Select2(emptyCase1, emptyCase2, true)
+	if idx != 0 {
+		t.Errorf("expected selected index=0 for closed channel, got %d", idx)
+	}
+	if emptyCase1.Ok {
+		t.Error("expected emptyCase1.Ok=false for closed channel, got true")
+	}
+	if emptyCase1.Value != 0 {
+		t.Errorf("expected emptyCase1.Value=0 (zero value) for closed channel, got %v", emptyCase1.Value)
+	}
+}
+
+func TestSelect3(t *testing.T) {
+	// Three buffered channels so we can preload one without blocking
+	c1 := channel.NewChannelRef[uint64](1) // capacity=1
+	c2 := channel.NewChannelRef[uint64](1) // capacity=1
+	c3 := channel.NewChannelRef[uint64](1) // capacity=1
+	// preload c3
+	c3.Send(88)
+
+	// build the cases (generic used explicitly)
+	case1 := channel.NewRecvCase(c1)
+	case2 := channel.NewRecvCase(c2)
+	case3 := channel.NewRecvCase(c3)
+
+	// non-blocking: should pick the third case (index 2)
+	idx := channel.Select3(case1, case2, case3, false)
+	if idx != 2 {
+		t.Errorf("expected selected index=2, got %d", idx)
+	}
+
+	// and confirm the SelectCase struct was populated
+	if case3.Value != 88 {
+		t.Errorf("expected case3.Value=88, got %v", case3.Value)
+	}
+	if !case3.Ok {
+		t.Error("expected case3.Ok=true, got false")
+	}
+
+	// Create new empty channels for testing non-blocking behavior
+	emptyC1 := channel.NewChannelRef[uint64](1)
+	emptyC2 := channel.NewChannelRef[uint64](1)
+	emptyC3 := channel.NewChannelRef[uint64](1)
+	emptyCase1 := channel.NewRecvCase(emptyC1)
+	emptyCase2 := channel.NewRecvCase(emptyC2)
+	emptyCase3 := channel.NewRecvCase(emptyC3)
+
+	// With blocking=false and no selectable statement, should return DefaultCase
+	idx = channel.Select3(emptyCase1, emptyCase2, emptyCase3, false)
+	if idx != 3 {
+		t.Errorf("expected selected index=3 when non-blocking with no available case, got %d", idx)
+	}
+
+	// Close a channel and test receive on closed channel
+	emptyC2.Close()
+	idx = channel.Select3(emptyCase1, emptyCase2, emptyCase3, true)
+	if idx != 1 {
+		t.Errorf("expected selected index=1 for closed channel, got %d", idx)
+	}
+	if emptyCase2.Ok {
+		t.Error("expected emptyCase2.Ok=false for closed channel, got true")
+	}
+	if emptyCase2.Value != 0 {
+		t.Errorf("expected emptyCase2.Value=0 (zero value) for closed channel, got %v", emptyCase2.Value)
+	}
+}
+
+func TestSelect4(t *testing.T) {
+	// Four buffered channels so we can preload one without blocking
+	c1 := channel.NewChannelRef[uint64](1) // capacity=1
+	c2 := channel.NewChannelRef[uint64](1) // capacity=1
+	c3 := channel.NewChannelRef[uint64](1) // capacity=1
+	c4 := channel.NewChannelRef[uint64](1) // capacity=1
+	// preload c4
+	c4.Send(99)
+
+	// build the cases (generic used explicitly)
+	case1 := channel.NewRecvCase(c1)
+	case2 := channel.NewRecvCase(c2)
+	case3 := channel.NewRecvCase(c3)
+	case4 := channel.NewRecvCase(c4)
+
+	// non-blocking: should pick the fourth case (index 3)
+	idx := channel.Select4(case1, case2, case3, case4, false)
+	if idx != 3 {
+		t.Errorf("expected selected index=3, got %d", idx)
+	}
+
+	// and confirm the SelectCase struct was populated
+	if case4.Value != 99 {
+		t.Errorf("expected case4.Value=99, got %v", case4.Value)
+	}
+	if !case4.Ok {
+		t.Error("expected case4.Ok=true, got false")
+	}
+
+	// Create new empty channels for testing non-blocking behavior
+	emptyC1 := channel.NewChannelRef[uint64](1)
+	emptyC2 := channel.NewChannelRef[uint64](1)
+	emptyC3 := channel.NewChannelRef[uint64](1)
+	emptyC4 := channel.NewChannelRef[uint64](1)
+	emptyCase1 := channel.NewRecvCase(emptyC1)
+	emptyCase2 := channel.NewRecvCase(emptyC2)
+	emptyCase3 := channel.NewRecvCase(emptyC3)
+	emptyCase4 := channel.NewRecvCase(emptyC4)
+
+	// With blocking=false and no selectable statement, should return DefaultCase
+	idx = channel.Select4(emptyCase1, emptyCase2, emptyCase3, emptyCase4, false)
+	if idx != 4 {
+		t.Errorf("expected selected index=4 when non-blocking with no available case, got %d", idx)
+	}
+
+	// Close a channel and test receive on closed channel
+	emptyC3.Close()
+	idx = channel.Select4(emptyCase1, emptyCase2, emptyCase3, emptyCase4, true)
+	if idx != 2 {
+		t.Errorf("expected selected index=2 for closed channel, got %d", idx)
+	}
+	if emptyCase3.Ok {
+		t.Error("expected emptyCase3.Ok=false for closed channel, got true")
+	}
+	if emptyCase3.Value != 0 {
+		t.Errorf("expected emptyCase3.Value=0 (zero value) for closed channel, got %v", emptyCase3.Value)
+	}
+}
+
+func TestSelect5(t *testing.T) {
+	// Five buffered channels so we can preload one without blocking
+	c1 := channel.NewChannelRef[uint64](1) // capacity=1
+	c2 := channel.NewChannelRef[uint64](1) // capacity=1
+	c3 := channel.NewChannelRef[uint64](1) // capacity=1
+	c4 := channel.NewChannelRef[uint64](1) // capacity=1
+	c5 := channel.NewChannelRef[uint64](1) // capacity=1
+	// preload c5
+	c5.Send(111)
+
+	// build the cases (generic used explicitly)
+	case1 := channel.NewRecvCase(c1)
+	case2 := channel.NewRecvCase(c2)
+	case3 := channel.NewRecvCase(c3)
+	case4 := channel.NewRecvCase(c4)
+	case5 := channel.NewRecvCase(c5)
+
+	// non-blocking: should pick the fifth case (index 4)
+	idx := channel.Select5(case1, case2, case3, case4, case5, false)
+	if idx != 4 {
+		t.Errorf("expected selected index=4, got %d", idx)
+	}
+
+	// and confirm the SelectCase struct was populated
+	if case5.Value != 111 {
+		t.Errorf("expected case5.Value=111, got %v", case5.Value)
+	}
+	if !case5.Ok {
+		t.Error("expected case5.Ok=true, got false")
+	}
+
+	// Create new empty channels for testing non-blocking behavior
+	emptyC1 := channel.NewChannelRef[uint64](1)
+	emptyC2 := channel.NewChannelRef[uint64](1)
+	emptyC3 := channel.NewChannelRef[uint64](1)
+	emptyC4 := channel.NewChannelRef[uint64](1)
+	emptyC5 := channel.NewChannelRef[uint64](1)
+	emptyCase1 := channel.NewRecvCase(emptyC1)
+	emptyCase2 := channel.NewRecvCase(emptyC2)
+	emptyCase3 := channel.NewRecvCase(emptyC3)
+	emptyCase4 := channel.NewRecvCase(emptyC4)
+	emptyCase5 := channel.NewRecvCase(emptyC5)
+
+	// With blocking=false and no selectable statement, should return DefaultCase
+	idx = channel.Select5(emptyCase1, emptyCase2, emptyCase3, emptyCase4, emptyCase5, false)
+	if idx != 5 {
+		t.Errorf("expected selected index=5 when non-blocking with no available case, got %d", idx)
+	}
+
+	// Close a channel and test receive on closed channel
+	emptyC4.Close()
+	idx = channel.Select5(emptyCase1, emptyCase2, emptyCase3, emptyCase4, emptyCase5, true)
+	if idx != 3 {
+		t.Errorf("expected selected index=3 for closed channel, got %d", idx)
+	}
+	if emptyCase4.Ok {
+		t.Error("expected emptyCase4.Ok=false for closed channel, got true")
+	}
+	if emptyCase4.Value != 0 {
+		t.Errorf("expected emptyCase4.Value=0 (zero value) for closed channel, got %v", emptyCase4.Value)
+	}
+}


### PR DESCRIPTION
Make the following changes:
1. Remove the "Multiselect" fallthrough and related functions and just use separate functions for each number of cases
2. Make it so we only select randomly on the first attempt. 
3. Add an explicit return statement to the end of Send
4. Added the channel tests I had in the master branch to the new branch

It was getting to be a real pain to try to use a shared 5 case fallthrough for the different numbers of cases

Using a single random attempt instead of a permutation is easier to prove and technically still ensures every immediately selectable case could be selected. In fact, it really isn't any different fairness wise than before if we don't create a new permutation on every loop. 

We don't currently support void functions without explicit return statements if they happen to have a call to a non-void function on the last line. I filed an issue for this 