### PR TITLE
Explicitly return #() from void functions

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -1535,7 +1535,11 @@ func (ctx *Ctx) funcLit(e *ast.FuncLit) glang.FuncLit {
 
 	ctx.curFuncType = ctx.typeOf(e.Type).(*types.Signature)
 	fl.Args = ctx.paramList(e.Type.Params)
-	fl.Body = ctx.blockStmt(e.Body, nil)
+	var cont glang.Expr = nil
+	if e.Type.Results == nil {
+		cont = glang.ReturnExpr{Value: glang.Tt}
+	}
+	fl.Body = ctx.blockStmt(e.Body, cont)
 
 	// Create heap-allocated variables for all of the function parameters
 	for _, arg := range fl.Args {
@@ -2647,7 +2651,11 @@ func (ctx *Ctx) funcDecl(d *ast.FuncDecl) []glang.Decl {
 		Value: defaultRetExpr,
 	}
 
-	body := ctx.blockStmt(d.Body, nil)
+	var cont glang.Expr = nil
+	if d.Type.Results == nil {
+		cont = glang.ReturnExpr{Value: glang.Tt}
+	}
+	body := ctx.blockStmt(d.Body, cont)
 
 	if d.Name.Name == "init" {
 		if ctx.usesDefer {

--- a/goose.go
+++ b/goose.go
@@ -1537,6 +1537,7 @@ func (ctx *Ctx) funcLit(e *ast.FuncLit) glang.FuncLit {
 	fl.Args = ctx.paramList(e.Type.Params)
 	var cont glang.Expr = nil
 	if e.Type.Results == nil {
+		// explicitly return #() at end of void functions
 		cont = glang.ReturnExpr{Value: glang.Tt}
 	}
 	fl.Body = ctx.blockStmt(e.Body, cont)
@@ -2653,6 +2654,7 @@ func (ctx *Ctx) funcDecl(d *ast.FuncDecl) []glang.Decl {
 
 	var cont glang.Expr = nil
 	if d.Type.Results == nil {
+		// explicitly return #() at end of void functions
 		cont = glang.ReturnExpr{Value: glang.Tt}
 	}
 	body := ctx.blockStmt(d.Body, cont)

--- a/testdata/examples/append_log/append_log.gold.v
+++ b/testdata/examples/append_log/append_log.gold.v
@@ -37,7 +37,8 @@ Definition Log__writeHdr : val :=
     exception_do (let: "log" := (mem.alloc "log") in
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := ((method_call #append_log.append_log #"Log'ptr" #"mkHdr" (![#ptrT] "log")) #()) in
-    (func_call #disk.disk #"Write"%go) "$a0" "$a1")).
+    (func_call #disk.disk #"Write"%go) "$a0" "$a1");;;
+    return: #()).
 
 (* go: append_log.go:33:6 *)
 Definition Init : val :=
@@ -138,7 +139,8 @@ Definition writeAll : val :=
       do:  ("i" <-[#intT] "$key");;;
       do:  (let: "$a0" := ((![#uint64T] "off") + (s_to_w64 (![#intT] "i"))) in
       let: "$a1" := (![#sliceT] "bk") in
-      (func_call #disk.disk #"Write"%go) "$a0" "$a1")))).
+      (func_call #disk.disk #"Write"%go) "$a0" "$a1")));;;
+    return: #()).
 
 (* go: append_log.go:71:17 *)
 Definition Log__append : val :=
@@ -179,7 +181,8 @@ Definition Log__reset : val :=
     exception_do (let: "log" := (mem.alloc "log") in
     let: "$r0" := #(W64 0) in
     do:  ((struct.field_ref #Log #"sz"%go (![#ptrT] "log")) <-[#uint64T] "$r0");;;
-    do:  ((method_call #append_log.append_log #"Log'ptr" #"writeHdr" (![#ptrT] "log")) #())).
+    do:  ((method_call #append_log.append_log #"Log'ptr" #"writeHdr" (![#ptrT] "log")) #());;;
+    return: #()).
 
 (* go: append_log.go:94:17 *)
 Definition Log__Reset : val :=
@@ -187,7 +190,8 @@ Definition Log__Reset : val :=
     exception_do (let: "log" := (mem.alloc "log") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"m"%go (![#ptrT] "log")))) #());;;
     do:  ((method_call #append_log.append_log #"Log'ptr" #"reset" (![#ptrT] "log")) #());;;
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"m"%go (![#ptrT] "log")))) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"m"%go (![#ptrT] "log")))) #());;;
+    return: #()).
 
 Definition vars' : list (go_string * go_type) := [].
 

--- a/testdata/examples/async/async.gold.v
+++ b/testdata/examples/async/async.gold.v
@@ -25,7 +25,8 @@ Definition UseDisk : val :=
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := (![#sliceT] "v") in
     (method_call #disk #"Disk" #"Write" (![#disk.Disk] "d")) "$a0" "$a1");;;
-    do:  ((method_call #disk #"Disk" #"Barrier" (![#disk.Disk] "d")) #())).
+    do:  ((method_call #disk #"Disk" #"Barrier" (![#disk.Disk] "d")) #());;;
+    return: #()).
 
 Definition vars' : list (go_string * go_type) := [].
 

--- a/testdata/examples/channel/channel.gold.v
+++ b/testdata/examples/channel/channel.gold.v
@@ -21,7 +21,8 @@ Definition SendMessage : val :=
     do:  ("messageChan" <-[#ptrT] "$r0");;;
     let: "$go" := (λ: <>,
       exception_do (do:  (let: "$a0" := #"hello world"%go in
-      (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "messageChan") #stringT) "$a0"))
+      (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "messageChan") #stringT) "$a0");;;
+      return: #())
       ) in
     do:  (Fork ("$go" #()));;;
     let: "message" := (mem.alloc (type.zero_val #stringT)) in
@@ -31,7 +32,8 @@ Definition SendMessage : val :=
     then
       do:  (let: "$a0" := (interface.make #""%go #"string"%go #"Did not receive expected message"%go) in
       Panic "$a0")
-    else do:  #())).
+    else do:  #());;;
+    return: #()).
 
 (* Example 2: Join goroutine with receive on unbuffered channel
 
@@ -49,7 +51,8 @@ Definition JoinWithReceive : val :=
       exception_do (let: "$r0" := #"hello world"%go in
       do:  ((![#ptrT] "message") <-[#stringT] "$r0");;;
       do:  (let: "$a0" := #(W64 0) in
-      (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "done") #uint64T) "$a0"))
+      (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "done") #uint64T) "$a0");;;
+      return: #())
       ) in
     do:  (Fork ("$go" #()));;;
     do:  ((method_call #channel #"Channel'ptr" #"ReceiveDiscardOk" (![#ptrT] "done") #uint64T) #());;;
@@ -57,7 +60,8 @@ Definition JoinWithReceive : val :=
     then
       do:  (let: "$a0" := (interface.make #""%go #"string"%go #"Message was not set correctly"%go) in
       Panic "$a0")
-    else do:  #())).
+    else do:  #());;;
+    return: #()).
 
 (* Example 3: Join goroutine with send on unbuffered channel
 
@@ -74,7 +78,8 @@ Definition JoinWithSend : val :=
     let: "$go" := (λ: <>,
       exception_do (let: "$r0" := #"hello world"%go in
       do:  ((![#ptrT] "message") <-[#stringT] "$r0");;;
-      do:  ((method_call #channel #"Channel'ptr" #"ReceiveDiscardOk" (![#ptrT] "done") #uint64T) #()))
+      do:  ((method_call #channel #"Channel'ptr" #"ReceiveDiscardOk" (![#ptrT] "done") #uint64T) #());;;
+      return: #())
       ) in
     do:  (Fork ("$go" #()));;;
     do:  (let: "$a0" := #(W64 0) in
@@ -83,7 +88,8 @@ Definition JoinWithSend : val :=
     then
       do:  (let: "$a0" := (interface.make #""%go #"string"%go #"Message was not set correctly"%go) in
       Panic "$a0")
-    else do:  #())).
+    else do:  #());;;
+    return: #()).
 
 (* Example 4: Broadcast notification with close. This is testing a case where
    we transfer disjoint ownership to different threads in a single broadcast
@@ -139,7 +145,8 @@ Definition BroadcastNotification : val :=
         else do:  #());;;
         do:  (let: "$a0" := #(W64 0) in
         (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "done1") #uint64T) "$a0")
-      else do:  #()))
+      else do:  #());;;
+      return: #())
       ) in
     do:  (Fork ("$go" #()));;;
     let: "$go" := (λ: <>,
@@ -158,7 +165,8 @@ Definition BroadcastNotification : val :=
         else do:  #());;;
         do:  (let: "$a0" := #(W64 0) in
         (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "done2") #uint64T) "$a0")
-      else do:  #()))
+      else do:  #());;;
+      return: #())
       ) in
     do:  (Fork ("$go" #()));;;
     let: "$go" := (λ: <>,
@@ -177,7 +185,8 @@ Definition BroadcastNotification : val :=
         else do:  #());;;
         do:  (let: "$a0" := #(W64 0) in
         (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "done3") #uint64T) "$a0")
-      else do:  #()))
+      else do:  #());;;
+      return: #())
       ) in
     do:  (Fork ("$go" #()));;;
     let: "$r0" := #"thread1"%go in
@@ -189,7 +198,8 @@ Definition BroadcastNotification : val :=
     do:  ((method_call #channel #"Channel'ptr" #"Close" (![#ptrT] "notifyCh") #uint64T) #());;;
     do:  ((method_call #channel #"Channel'ptr" #"ReceiveDiscardOk" (![#ptrT] "done1") #uint64T) #());;;
     do:  ((method_call #channel #"Channel'ptr" #"ReceiveDiscardOk" (![#ptrT] "done2") #uint64T) #());;;
-    do:  ((method_call #channel #"Channel'ptr" #"ReceiveDiscardOk" (![#ptrT] "done3") #uint64T) #())).
+    do:  ((method_call #channel #"Channel'ptr" #"ReceiveDiscardOk" (![#ptrT] "done3") #uint64T) #());;;
+    return: #()).
 
 (* Example 5: Join sending goroutine before closing a buffered channel.
    This should demonstrate the spec's ability to prevent closing on a channel
@@ -210,7 +220,8 @@ Definition CoordinatedChannelClose : val :=
       exception_do (do:  (let: "$a0" := #(W64 42) in
       (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "bufCh") #uint64T) "$a0");;;
       do:  (let: "$a0" := #(W64 0) in
-      (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "syncCh") #uint64T) "$a0"))
+      (method_call #channel #"Channel'ptr" #"Send" (![#ptrT] "syncCh") #uint64T) "$a0");;;
+      return: #())
       ) in
     do:  (Fork ("$go" #()));;;
     do:  (let: "$a0" := #(W64 84) in
@@ -240,7 +251,8 @@ Definition CoordinatedChannelClose : val :=
     then
       do:  (let: "$a0" := (interface.make #""%go #"string"%go #"Did not receive both expected values"%go) in
       Panic "$a0")
-    else do:  #())).
+    else do:  #());;;
+    return: #()).
 
 Definition vars' : list (go_string * go_type) := [].
 

--- a/testdata/examples/externalglobals/externalglobals.gold.v
+++ b/testdata/examples/externalglobals/externalglobals.gold.v
@@ -13,7 +13,8 @@ Section code.
 Definition f : val :=
   rec: "f" <> :=
     exception_do (let: "$r0" := #(W64 11) in
-    do:  ((globals.get #unittest #"GlobalX"%go) <-[#uint64T] "$r0")).
+    do:  ((globals.get #unittest #"GlobalX"%go) <-[#uint64T] "$r0");;;
+    return: #()).
 
 Definition vars' : list (go_string * go_type) := [].
 

--- a/testdata/examples/interfacerecursion/interfacerecursion.gold.v
+++ b/testdata/examples/interfacerecursion/interfacerecursion.gold.v
@@ -22,7 +22,8 @@ Definition c__Foo : val :=
     let: "y" := (mem.alloc (type.zero_val #B)) in
     let: "$r0" := (interface.make #interfacerecursion.interfacerecursion #"c'ptr" (![#ptrT] "c")) in
     do:  ("y" <-[#B] "$r0");;;
-    do:  ((interface.get #"Bar"%go (![#B] "y")) #())).
+    do:  ((interface.get #"Bar"%go (![#B] "y")) #());;;
+    return: #()).
 
 (* go: x.go:19:13 *)
 Definition c__Bar : val :=
@@ -31,7 +32,8 @@ Definition c__Bar : val :=
     let: "y" := (mem.alloc (type.zero_val #A)) in
     let: "$r0" := (interface.make #interfacerecursion.interfacerecursion #"c'ptr" (![#ptrT] "c")) in
     do:  ("y" <-[#A] "$r0");;;
-    do:  ((interface.get #"Foo"%go (![#A] "y")) #())).
+    do:  ((interface.get #"Foo"%go (![#A] "y")) #());;;
+    return: #()).
 
 Definition vars' : list (go_string * go_type) := [].
 

--- a/testdata/examples/logging2/logging2.gold.v
+++ b/testdata/examples/logging2/logging2.gold.v
@@ -42,7 +42,8 @@ Definition Log__writeHdr : val :=
     (func_call #primitive.primitive #"UInt64Put"%go) "$a0" "$a1");;;
     do:  (let: "$a0" := LOGCOMMIT in
     let: "$a1" := (![#sliceT] "hdr") in
-    (func_call #disk.disk #"Write"%go) "$a0" "$a1")).
+    (func_call #disk.disk #"Write"%go) "$a0" "$a1");;;
+    return: #()).
 
 (* go: logging2.go:31:6 *)
 Definition Init : val :=
@@ -139,7 +140,8 @@ Definition Log__memWrite : val :=
       let: "$a1" := ((let: "$sl0" := (![#sliceT] (slice.elem_ref #sliceT (![#sliceT] "l") (![#uint64T] "i"))) in
       slice.literal #sliceT ["$sl0"])) in
       (slice.append #sliceT) "$a0" "$a1") in
-      do:  ((![#ptrT] (struct.field_ref #Log #"memLog"%go "log")) <-[#sliceT] "$r0")))).
+      do:  ((![#ptrT] (struct.field_ref #Log #"memLog"%go "log")) <-[#sliceT] "$r0")));;;
+    return: #()).
 
 (* go: logging2.go:75:16 *)
 Definition Log__memAppend : val :=
@@ -192,7 +194,8 @@ Definition Log__diskAppendWait : val :=
       (if: (![#uint64T] "txn") < (![#uint64T] "logtxn")
       then break: #()
       else do:  #());;;
-      continue: #())).
+      continue: #());;;
+    return: #()).
 
 (* go: logging2.go:107:16 *)
 Definition Log__Append : val :=
@@ -233,7 +236,8 @@ Definition Log__writeBlocks : val :=
       do:  ("bk" <-[#sliceT] "$r0");;;
       do:  (let: "$a0" := ((![#uint64T] "pos") + (![#uint64T] "i")) in
       let: "$a1" := (![#sliceT] "bk") in
-      (func_call #disk.disk #"Write"%go) "$a0" "$a1")))).
+      (func_call #disk.disk #"Write"%go) "$a0" "$a1")));;;
+    return: #()).
 
 (* go: logging2.go:123:16 *)
 Definition Log__diskAppend : val :=
@@ -265,14 +269,16 @@ Definition Log__diskAppend : val :=
     (method_call #logging2.logging2 #"Log" #"writeHdr" (![#Log] "log")) "$a0");;;
     let: "$r0" := (![#uint64T] "memnxt") in
     do:  ((![#ptrT] (struct.field_ref #Log #"logTxnNxt"%go "log")) <-[#uint64T] "$r0");;;
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"logLock"%go "log"))) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"logLock"%go "log"))) #());;;
+    return: #()).
 
 (* go: logging2.go:142:16 *)
 Definition Log__Logger : val :=
   rec: "Log__Logger" "log" <> :=
     exception_do (let: "log" := (mem.alloc "log") in
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      do:  ((method_call #logging2.logging2 #"Log" #"diskAppend" (![#Log] "log")) #()))).
+      do:  ((method_call #logging2.logging2 #"Log" #"diskAppend" (![#Log] "log")) #()));;;
+    return: #()).
 
 Definition Txn : go_type := structT [
   "log" :: ptrT;

--- a/testdata/examples/mutualrec/mutualrec.gold.v
+++ b/testdata/examples/mutualrec/mutualrec.gold.v
@@ -11,12 +11,14 @@ Context `{ffi_syntax}.
 (* go: mutualrec.go:3:6 *)
 Definition A : val :=
   rec: "A" <> :=
-    exception_do (do:  ((func_call #mutualrec.mutualrec #"B"%go) #())).
+    exception_do (do:  ((func_call #mutualrec.mutualrec #"B"%go) #());;;
+    return: #()).
 
 (* go: mutualrec.go:7:6 *)
 Definition B : val :=
   rec: "B" <> :=
-    exception_do (do:  ((func_call #mutualrec.mutualrec #"A"%go) #())).
+    exception_do (do:  ((func_call #mutualrec.mutualrec #"A"%go) #());;;
+    return: #()).
 
 Definition vars' : list (go_string * go_type) := [].
 

--- a/testdata/examples/semantics/semantics.gold.v
+++ b/testdata/examples/semantics/semantics.gold.v
@@ -408,7 +408,8 @@ Definition deferSimple : val :=
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 10)); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
       do:  (let: "$f" := (λ: <>,
-        exception_do (do:  ((![#ptrT] "x") <-[#uint64T] ((![#uint64T] (![#ptrT] "x")) + #(W64 1))))
+        exception_do (do:  ((![#ptrT] "x") <-[#uint64T] ((![#uint64T] (![#ptrT] "x")) + #(W64 1)));;;
+        return: #())
         ) in
       "$defer" <-[#funcT] (let: "$oldf" := (![#funcT] "$defer") in
       (λ: <>,
@@ -431,13 +432,15 @@ Definition testDeferFuncLit : val :=
     let: "f" := (mem.alloc (type.zero_val #funcT)) in
     let: "$r0" := (λ: <>,
       with_defer: (do:  (let: "$f" := (λ: <>,
-        exception_do (do:  ("x" <-[#intT] ((![#intT] "x") + #(W64 1))))
+        exception_do (do:  ("x" <-[#intT] ((![#intT] "x") + #(W64 1)));;;
+        return: #())
         ) in
       "$defer" <-[#funcT] (let: "$oldf" := (![#funcT] "$defer") in
       (λ: <>,
         "$f" #();;
         "$oldf" #()
-        ))))
+        )));;;
+      return: #())
       ) in
     do:  ("f" <-[#funcT] "$r0");;;
     do:  ((![#funcT] "f") #());;;
@@ -1030,7 +1033,8 @@ Definition LoopStruct__forLoopWait : val :=
       else do:  #());;;
       let: "$r0" := ((![#uint64T] (![#ptrT] (struct.field_ref #LoopStruct #"loopNext"%go "ls"))) + #(W64 1)) in
       do:  ((![#ptrT] (struct.field_ref #LoopStruct #"loopNext"%go "ls")) <-[#uint64T] "$r0");;;
-      continue: #())).
+      continue: #());;;
+    return: #()).
 
 (* tests
 
@@ -1894,7 +1898,8 @@ Definition ArrayEditor__Advance : val :=
     do:  ((struct.field_ref #ArrayEditor #"next_val"%go (![#ptrT] "ae")) <-[#uint64T] "$r0");;;
     let: "$r0" := (let: "$s" := (![#sliceT] (struct.field_ref #ArrayEditor #"s"%go (![#ptrT] "ae"))) in
     slice.slice #uint64T "$s" #(W64 1) (slice.len "$s")) in
-    do:  ((struct.field_ref #ArrayEditor #"s"%go (![#ptrT] "ae")) <-[#sliceT] "$r0")).
+    do:  ((struct.field_ref #ArrayEditor #"s"%go (![#ptrT] "ae")) <-[#sliceT] "$r0");;;
+    return: #()).
 
 (* tests
 
@@ -2107,13 +2112,15 @@ Definition Bar__mutate : val :=
     let: "$r0" := #(W64 2) in
     do:  ((struct.field_ref #Bar #"a"%go (![#ptrT] "bar")) <-[#uint64T] "$r0");;;
     let: "$r0" := #(W64 3) in
-    do:  ((struct.field_ref #Bar #"b"%go (![#ptrT] "bar")) <-[#uint64T] "$r0")).
+    do:  ((struct.field_ref #Bar #"b"%go (![#ptrT] "bar")) <-[#uint64T] "$r0");;;
+    return: #()).
 
 (* go: struct_pointers.go:19:17 *)
 Definition Foo__mutateBar : val :=
   rec: "Foo__mutateBar" "foo" <> :=
     exception_do (let: "foo" := (mem.alloc "foo") in
-    do:  ((method_call #semantics.semantics #"Bar'ptr" #"mutate" (struct.field_ref #Foo #"bar"%go (![#ptrT] "foo"))) #())).
+    do:  ((method_call #semantics.semantics #"Bar'ptr" #"mutate" (struct.field_ref #Foo #"bar"%go (![#ptrT] "foo"))) #());;;
+    return: #()).
 
 (* go: struct_pointers.go:23:6 *)
 Definition testFooBarMutation : val :=
@@ -2184,14 +2191,16 @@ Definition S__updateBValX : val :=
     exception_do (let: "s" := (mem.alloc "s") in
     let: "i" := (mem.alloc "i") in
     let: "$r0" := (![#uint64T] "i") in
-    do:  ((struct.field_ref #TwoInts #"x"%go (struct.field_ref #S #"b"%go (![#ptrT] "s"))) <-[#uint64T] "$r0")).
+    do:  ((struct.field_ref #TwoInts #"x"%go (struct.field_ref #S #"b"%go (![#ptrT] "s"))) <-[#uint64T] "$r0");;;
+    return: #()).
 
 (* go: structs.go:38:13 *)
 Definition S__negateC : val :=
   rec: "S__negateC" "s" <> :=
     exception_do (let: "s" := (mem.alloc "s") in
     let: "$r0" := (~ (![#boolT] (struct.field_ref #S #"c"%go (![#ptrT] "s")))) in
-    do:  ((struct.field_ref #S #"c"%go (![#ptrT] "s")) <-[#boolT] "$r0")).
+    do:  ((struct.field_ref #S #"c"%go (![#ptrT] "s")) <-[#boolT] "$r0");;;
+    return: #()).
 
 (* go: structs.go:42:6 *)
 Definition testStructUpdates : val :=
@@ -2596,13 +2605,15 @@ Definition New : val :=
 Definition Log__lock : val :=
   rec: "Log__lock" "l" <> :=
     exception_do (let: "l" := (mem.alloc "l") in
-    do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #());;;
+    return: #()).
 
 (* go: wal.go:56:14 *)
 Definition Log__unlock : val :=
   rec: "Log__unlock" "l" <> :=
     exception_do (let: "l" := (mem.alloc "l") in
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #());;;
+    return: #()).
 
 (* BeginTxn allocates space for a new transaction in the log.
 
@@ -2696,7 +2707,8 @@ Definition Log__Write : val :=
     do:  (map.insert (![type.mapT #uint64T #sliceT] (struct.field_ref #Log #"cache"%go "l")) (![#uint64T] "a") "$r0");;;
     let: "$r0" := ((![#uint64T] "length") + #(W64 1)) in
     do:  ((![#ptrT] (struct.field_ref #Log #"length"%go "l")) <-[#uint64T] "$r0");;;
-    do:  ((method_call #semantics.semantics #"Log" #"unlock" (![#Log] "l")) #())).
+    do:  ((method_call #semantics.semantics #"Log" #"unlock" (![#Log] "l")) #());;;
+    return: #()).
 
 (* Commit the current transaction.
 
@@ -2715,7 +2727,8 @@ Definition Log__Commit : val :=
     do:  ("header" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := (![#sliceT] "header") in
-    (interface.get #"Write"%go (![#disk.Disk] (struct.field_ref #Log #"d"%go "l"))) "$a0" "$a1")).
+    (interface.get #"Write"%go (![#disk.Disk] (struct.field_ref #Log #"d"%go "l"))) "$a0" "$a1");;;
+    return: #()).
 
 (* go: wal.go:122:6 *)
 Definition getLogEntry : val :=
@@ -2768,7 +2781,8 @@ Definition applyLog : val :=
         do:  ("i" <-[#uint64T] "$r0");;;
         continue: #()
       else do:  #());;;
-      break: #()))).
+      break: #()));;;
+    return: #()).
 
 (* go: wal.go:142:6 *)
 Definition clearLog : val :=
@@ -2780,7 +2794,8 @@ Definition clearLog : val :=
     do:  ("header" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := (![#sliceT] "header") in
-    (interface.get #"Write"%go (![#disk.Disk] "d")) "$a0" "$a1")).
+    (interface.get #"Write"%go (![#disk.Disk] "d")) "$a0" "$a1");;;
+    return: #()).
 
 (* Apply all the committed transactions.
 
@@ -2801,7 +2816,8 @@ Definition Log__Apply : val :=
     (func_call #semantics.semantics #"clearLog"%go) "$a0");;;
     let: "$r0" := #(W64 0) in
     do:  ((![#ptrT] (struct.field_ref #Log #"length"%go "l")) <-[#uint64T] "$r0");;;
-    do:  ((method_call #semantics.semantics #"Log" #"unlock" (![#Log] "l")) #())).
+    do:  ((method_call #semantics.semantics #"Log" #"unlock" (![#Log] "l")) #());;;
+    return: #()).
 
 (* Open recovers the log following a crash or shutdown
 

--- a/testdata/examples/simpledb/simpledb.gold.v
+++ b/testdata/examples/simpledb/simpledb.gold.v
@@ -16,7 +16,8 @@ Context `{ffi_syntax}.
 Definition UseMarshal : val :=
   rec: "UseMarshal" <> :=
     exception_do (do:  (let: "$a0" := #(W64 0) in
-    (func_call #marshal.marshal #"NewEnc"%go) "$a0")).
+    (func_call #marshal.marshal #"NewEnc"%go) "$a0");;;
+    return: #()).
 
 Definition Table : go_type := structT [
   "Index" :: mapT uint64T uint64T;
@@ -208,7 +209,8 @@ Definition readTableIndex : val :=
             "next" ::= "$next"
           }]) in
           do:  ("buf" <-[#lazyFileBuf] "$r0");;;
-          continue: #()))))).
+          continue: #()))));;;
+    return: #()).
 
 (* RecoverTable restores a table from disk on startup.
 
@@ -241,7 +243,8 @@ Definition CloseTable : val :=
   rec: "CloseTable" "t" :=
     exception_do (let: "t" := (mem.alloc "t") in
     do:  (let: "$a0" := (![#fileT] (struct.field_ref #Table #"File"%go "t")) in
-    (func_call #filesys.filesys #"Close"%go) "$a0")).
+    (func_call #filesys.filesys #"Close"%go) "$a0");;;
+    return: #()).
 
 (* go: simpledb.go:123:6 *)
 Definition readValue : val :=
@@ -340,7 +343,8 @@ Definition bufFlush : val :=
     let: "$a1" := (![#sliceT] "buf") in
     (func_call #filesys.filesys #"Append"%go) "$a0" "$a1");;;
     let: "$r0" := #slice.nil in
-    do:  ((![#ptrT] (struct.field_ref #bufFile #"buf"%go "f")) <-[#sliceT] "$r0")).
+    do:  ((![#ptrT] (struct.field_ref #bufFile #"buf"%go "f")) <-[#sliceT] "$r0");;;
+    return: #()).
 
 (* go: simpledb.go:168:6 *)
 Definition bufAppend : val :=
@@ -356,7 +360,8 @@ Definition bufAppend : val :=
     (slice.append #byteT) "$a0" "$a1") in
     do:  ("buf2" <-[#sliceT] "$r0");;;
     let: "$r0" := (![#sliceT] "buf2") in
-    do:  ((![#ptrT] (struct.field_ref #bufFile #"buf"%go "f")) <-[#sliceT] "$r0")).
+    do:  ((![#ptrT] (struct.field_ref #bufFile #"buf"%go "f")) <-[#sliceT] "$r0");;;
+    return: #()).
 
 (* go: simpledb.go:174:6 *)
 Definition bufClose : val :=
@@ -365,7 +370,8 @@ Definition bufClose : val :=
     do:  (let: "$a0" := (![#bufFile] "f") in
     (func_call #simpledb.simpledb #"bufFlush"%go) "$a0");;;
     do:  (let: "$a0" := (![#fileT] (struct.field_ref #bufFile #"file"%go "f")) in
-    (func_call #filesys.filesys #"Close"%go) "$a0")).
+    (func_call #filesys.filesys #"Close"%go) "$a0");;;
+    return: #()).
 
 Definition tableWriter : go_type := structT [
   "index" :: mapT uint64T uint64T;
@@ -420,7 +426,8 @@ Definition tableWriterAppend : val :=
     do:  ("off" <-[#uint64T] "$r0");;;
     let: "$r0" := ((![#uint64T] "off") + (s_to_w64 (let: "$a0" := (![#sliceT] "p") in
     slice.len "$a0"))) in
-    do:  ((![#ptrT] (struct.field_ref #tableWriter #"offset"%go "w")) <-[#uint64T] "$r0")).
+    do:  ((![#ptrT] (struct.field_ref #tableWriter #"offset"%go "w")) <-[#uint64T] "$r0");;;
+    return: #()).
 
 (* go: simpledb.go:205:6 *)
 Definition tableWriterClose : val :=
@@ -507,7 +514,8 @@ Definition tablePut : val :=
     do:  (map.insert (![type.mapT #uint64T #uint64T] (struct.field_ref #tableWriter #"index"%go "w")) (![#uint64T] "k") "$r0");;;
     do:  (let: "$a0" := (![#tableWriter] "w") in
     let: "$a1" := (![#sliceT] "tmp3") in
-    (func_call #simpledb.simpledb #"tableWriterAppend"%go) "$a0" "$a1")).
+    (func_call #simpledb.simpledb #"tableWriterAppend"%go) "$a0" "$a1");;;
+    return: #()).
 
 Definition Database : go_type := structT [
   "wbuffer" :: ptrT;
@@ -663,7 +671,8 @@ Definition Write : val :=
     do:  ("buf" <-[type.mapT #uint64T #sliceT] "$r0");;;
     let: "$r0" := (![#sliceT] "v") in
     do:  (map.insert (![type.mapT #uint64T #sliceT] "buf") (![#uint64T] "k") "$r0");;;
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #());;;
+    return: #()).
 
 (* go: simpledb.go:333:6 *)
 Definition freshTable : val :=
@@ -691,7 +700,8 @@ Definition tablePutBuffer : val :=
       do:  (let: "$a0" := (![#tableWriter] "w") in
       let: "$a1" := (![#uint64T] "k") in
       let: "$a2" := (![#sliceT] "v") in
-      (func_call #simpledb.simpledb #"tablePut"%go) "$a0" "$a1" "$a2")))).
+      (func_call #simpledb.simpledb #"tablePut"%go) "$a0" "$a1" "$a2")));;;
+    return: #()).
 
 (* add all of table t to the table w being created; skip any keys in the (read)
    buffer b since those writes overwrite old ones
@@ -767,7 +777,8 @@ Definition tablePutOldTable : val :=
             "next" ::= "$next"
           }]) in
           do:  ("buf" <-[#lazyFileBuf] "$r0");;;
-          continue: #()))))).
+          continue: #()))));;;
+    return: #()).
 
 (* Build a new shadow table that incorporates the current table and a
    (write) buffer wbuf.
@@ -864,7 +875,8 @@ Definition Compact : val :=
     let: "$a1" := (![#stringT] "oldTableName") in
     (func_call #filesys.filesys #"Delete"%go) "$a0" "$a1");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"tableL"%go "db"))) #());;;
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"compactionL"%go "db"))) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"compactionL"%go "db"))) #());;;
+    return: #()).
 
 (* go: simpledb.go:450:6 *)
 Definition recoverManifest : val :=
@@ -902,7 +914,8 @@ Definition deleteOtherFile : val :=
     else do:  #());;;
     do:  (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "name") in
-    (func_call #filesys.filesys #"Delete"%go) "$a0" "$a1")).
+    (func_call #filesys.filesys #"Delete"%go) "$a0" "$a1");;;
+    return: #()).
 
 (* go: simpledb.go:474:6 *)
 Definition deleteOtherFiles : val :=
@@ -931,7 +944,8 @@ Definition deleteOtherFiles : val :=
       (func_call #simpledb.simpledb #"deleteOtherFile"%go) "$a0" "$a1");;;
       let: "$r0" := ((![#uint64T] "i") + #(W64 1)) in
       do:  ("i" <-[#uint64T] "$r0");;;
-      continue: #()))).
+      continue: #()));;;
+    return: #()).
 
 (* Recover restores a previously created database after a crash or shutdown.
 
@@ -1006,7 +1020,8 @@ Definition Shutdown : val :=
     do:  (let: "$a0" := (![#Table] "t") in
     (func_call #simpledb.simpledb #"CloseTable"%go) "$a0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"compactionL"%go "db"))) #());;;
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #());;;
+    return: #()).
 
 (* Close closes an open database cleanly, flushing any in-memory writes.
 
@@ -1019,7 +1034,8 @@ Definition Close : val :=
     do:  (let: "$a0" := (![#Database] "db") in
     (func_call #simpledb.simpledb #"Compact"%go) "$a0");;;
     do:  (let: "$a0" := (![#Database] "db") in
-    (func_call #simpledb.simpledb #"Shutdown"%go) "$a0")).
+    (func_call #simpledb.simpledb #"Shutdown"%go) "$a0");;;
+    return: #()).
 
 Definition vars' : list (go_string * go_type) := [].
 

--- a/testdata/examples/unittest/generics/generics.gold.v
+++ b/testdata/examples/unittest/generics/generics.gold.v
@@ -91,7 +91,8 @@ Definition useContainer : val :=
     let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ((struct.field_ref (Container #uint64T) #"Z"%go "container") <-[#ptrT] "$r0");;;
     let: "$r0" := #(W64 4) in
-    do:  ((struct.field_ref (Container #uint64T) #"W"%go "container") <-[#uint64T] "$r0")).
+    do:  ((struct.field_ref (Container #uint64T) #"W"%go "container") <-[#uint64T] "$r0");;;
+    return: #()).
 
 Definition UseContainer : val :=
   λ: <>, type.structT [
@@ -122,7 +123,8 @@ Definition useMultiParam : val :=
     }]) in
     do:  ("mp" <-[MultiParam #uint64T #boolT] "$r0");;;
     let: "$r0" := #(W64 2) in
-    do:  ((struct.field_ref (MultiParam #uint64T #boolT) #"X"%go "mp") <-[#uint64T] "$r0")).
+    do:  ((struct.field_ref (MultiParam #uint64T #boolT) #"X"%go "mp") <-[#uint64T] "$r0");;;
+    return: #()).
 
 (* go: generics.go:76:6 *)
 Definition swapMultiParam : val :=
@@ -134,7 +136,8 @@ Definition swapMultiParam : val :=
     let: "$r0" := (!["A"] (struct.field_ref (MultiParam "A" "A") #"Y"%go (![#ptrT] "p"))) in
     do:  ((struct.field_ref (MultiParam "A" "A") #"X"%go (![#ptrT] "p")) <-["A"] "$r0");;;
     let: "$r0" := (!["A"] "temp") in
-    do:  ((struct.field_ref (MultiParam "A" "A") #"Y"%go (![#ptrT] "p")) <-["A"] "$r0")).
+    do:  ((struct.field_ref (MultiParam "A" "A") #"Y"%go (![#ptrT] "p")) <-["A"] "$r0");;;
+    return: #()).
 
 (* go: generics.go:82:6 *)
 Definition multiParamFunc : val :=
@@ -150,7 +153,8 @@ Definition useMultiParamFunc : val :=
     exception_do (do:  (let: "$a0" := #(W64 1) in
     let: "$a1" := #true in
     ((func_call #generics.generics #"multiParamFunc"%go) #uint64T #boolT) "$a0" "$a1");;;
-    return: (#())).
+    return: (#());;;
+    return: #()).
 
 Definition vars' : list (go_string * go_type) := [].
 

--- a/testdata/examples/unittest/returns.go
+++ b/testdata/examples/unittest/returns.go
@@ -35,8 +35,8 @@ func VoidButEndsWithReturn() {
 	BasicNamedReturn()
 }
 
-func VoidImplicitReturnInBranch() {
-	if true {
+func VoidImplicitReturnInBranch(b bool) {
+	if b {
 		return
 	} else {
 		BasicNamedReturn()

--- a/testdata/examples/unittest/returns.go
+++ b/testdata/examples/unittest/returns.go
@@ -28,3 +28,17 @@ func NamedReturnOverride() (x string, y string) {
 	}
 	return
 }
+
+func VoidButEndsWithReturn() {
+	// translation should not produce the value from this function call since the
+	// outer function is void
+	BasicNamedReturn()
+}
+
+func VoidImplicitReturnInBranch() {
+	if true {
+		return
+	} else {
+		BasicNamedReturn()
+	}
+}

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -26,7 +26,8 @@ Definition takesArray : val :=
 Definition takesPtr : val :=
   rec: "takesPtr" "x" :=
     exception_do (let: "x" := (mem.alloc "x") in
-    do:  ((![#ptrT] "x") <-[#stringT] ((![#stringT] (![#ptrT] "x")) + #"bar"%go))).
+    do:  ((![#ptrT] "x") <-[#stringT] ((![#stringT] (![#ptrT] "x")) + #"bar"%go));;;
+    return: #()).
 
 (* go: array.go:13:6 *)
 Definition usesArrayElemRef : val :=
@@ -39,7 +40,8 @@ Definition usesArrayElemRef : val :=
     let: "$r0" := #"c"%go in
     do:  ((array.elem_ref #stringT (![type.arrayT #(W64 2) #stringT] "x") #(W64 1)) <-[#stringT] "$r0");;;
     do:  (let: "$a0" := (array.elem_ref #stringT (![type.arrayT #(W64 2) #stringT] "x") #(W64 1)) in
-    (func_call #unittest.unittest #"takesPtr"%go) "$a0")).
+    (func_call #unittest.unittest #"takesPtr"%go) "$a0");;;
+    return: #()).
 
 (* go: array.go:22:6 *)
 Definition sum : val :=
@@ -106,7 +108,8 @@ Definition chanBasic : val :=
       chan.send "$chan" "$v");;;
       do:  (let: "$chan" := (![type.chanT #stringT] "x") in
       let: "$v" := #"Foo"%go in
-      chan.send "$chan" "$v"))
+      chan.send "$chan" "$v");;;
+      return: #())
       ) in
     do:  (Fork ("$go" #()));;;
     let: "ok" := (mem.alloc (type.zero_val #boolT)) in
@@ -122,7 +125,8 @@ Definition chanBasic : val :=
     then
       let: "$r0" := ((![#stringT] "y") + #" "%go) in
       do:  ("y" <-[#stringT] "$r0")
-    else do:  #())).
+    else do:  #());;;
+    return: #()).
 
 (* go: chan.go:20:6 *)
 Definition f : val :=
@@ -197,7 +201,8 @@ Definition chanSelect : val :=
          ); chan.select_send #(W64 1) (![type.chanT #intT] "c") (λ: <>,
          do:  #()
          )] chan.select_no_default);;;
-    chan.select [] chan.select_no_default).
+    chan.select [] chan.select_no_default;;;
+    return: #()).
 
 (* go: chan.go:59:6 *)
 Definition chanDirectional : val :=
@@ -207,7 +212,8 @@ Definition chanDirectional : val :=
     do:  (Fst (chan.receive (![type.chanT #uint64T] "x")));;;
     do:  (let: "$chan" := (![type.chanT #stringT] "y") in
     let: "$v" := #""%go in
-    chan.send "$chan" "$v")).
+    chan.send "$chan" "$v");;;
+    return: #()).
 
 (* go: chan.go:66:6 *)
 Definition chanRange : val :=
@@ -229,7 +235,8 @@ Definition chanRange : val :=
       (func_call #fmt.fmt #"Print"%go) "$a0")));;;
     let: "$range" := (![type.chanT #uint64T] "x") in
     chan.for_range "$range" (λ: "$key",
-      do:  #())).
+      do:  #());;;
+    return: #()).
 
 Definition importantStruct : go_type := structT [
 ].
@@ -269,7 +276,8 @@ Definition condvarWrapping : val :=
     do:  ("cond1" <-[#ptrT] "$r0");;;
     let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("mu" <-[#ptrT] "$r0");;;
-    do:  ((method_call #sync #"Cond'ptr" #"Wait" (![#ptrT] "cond1")) #())).
+    do:  ((method_call #sync #"Cond'ptr" #"Wait" (![#ptrT] "cond1")) #());;;
+    return: #()).
 
 Definition GlobalConstant : expr := #"foo"%go.
 
@@ -354,7 +362,8 @@ Definition earlyReturn : val :=
     exception_do (let: "x" := (mem.alloc "x") in
     (if: ![#boolT] "x"
     then return: (#())
-    else do:  #())).
+    else do:  #());;;
+    return: #()).
 
 (* go: control_flow.go:38:6 *)
 Definition conditionalAssign : val :=
@@ -530,7 +539,8 @@ Definition useSlice : val :=
     do:  (let: "$a0" := #"dir"%go in
     let: "$a1" := #"file"%go in
     let: "$a2" := (![#sliceT] "s1") in
-    (func_call #unittest.unittest #"atomicCreateStub"%go) "$a0" "$a1" "$a2")).
+    (func_call #unittest.unittest #"atomicCreateStub"%go) "$a0" "$a1" "$a2");;;
+    return: #()).
 
 (* go: data_structures.go:15:6 *)
 Definition useSliceIndexing : val :=
@@ -564,7 +574,8 @@ Definition useMap : val :=
     then return: (#())
     else do:  #());;;
     let: "$r0" := (![#sliceT] "x") in
-    do:  (map.insert (![type.mapT #uint64T #sliceT] "m") #(W64 3) "$r0")).
+    do:  (map.insert (![type.mapT #uint64T #sliceT] "m") #(W64 3) "$r0");;;
+    return: #()).
 
 (* go: data_structures.go:32:6 *)
 Definition usePtr : val :=
@@ -578,7 +589,8 @@ Definition usePtr : val :=
     let: "$r0" := (![#uint64T] (![#ptrT] "p")) in
     do:  ("x" <-[#uint64T] "$r0");;;
     let: "$r0" := (![#uint64T] "x") in
-    do:  ((![#ptrT] "p") <-[#uint64T] "$r0")).
+    do:  ((![#ptrT] "p") <-[#uint64T] "$r0");;;
+    return: #()).
 
 (* go: data_structures.go:39:6 *)
 Definition iterMapKeysAndValues : val :=
@@ -657,7 +669,8 @@ Definition diskArgument : val :=
     do:  ("b" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := #(W64 1) in
     let: "$a1" := (![#sliceT] "b") in
-    (interface.get #"Write"%go (![#disk.Disk] "d")) "$a0" "$a1")).
+    (interface.get #"Write"%go (![#disk.Disk] "d")) "$a0" "$a1");;;
+    return: #()).
 
 Definition embedA : go_type := structT [
   "a" :: uint64T
@@ -764,7 +777,8 @@ Definition empty : val :=
 (* go: empty_functions.go:5:6 *)
 Definition emptyReturn : val :=
   rec: "emptyReturn" <> :=
-    exception_do (return: (#())).
+    exception_do (return: (#());;;
+    return: #()).
 
 (* go: empty_functions.go:9:6 *)
 Definition unnamedParams : val :=
@@ -802,7 +816,8 @@ Definition Enc__UInt64 : val :=
     do:  (let: "$a0" := (let: "$a0" := #(W64 8) in
     (method_call #unittest.unittest #"Enc'ptr" #"consume" (![#ptrT] "e")) "$a0") in
     let: "$a1" := (![#uint64T] "x") in
-    (func_call #primitive.primitive #"UInt64Put"%go) "$a0" "$a1")).
+    (func_call #primitive.primitive #"UInt64Put"%go) "$a0" "$a1");;;
+    return: #()).
 
 (* go: encoding.go:19:15 *)
 Definition Enc__UInt32 : val :=
@@ -812,7 +827,8 @@ Definition Enc__UInt32 : val :=
     do:  (let: "$a0" := (let: "$a0" := #(W64 4) in
     (method_call #unittest.unittest #"Enc'ptr" #"consume" (![#ptrT] "e")) "$a0") in
     let: "$a1" := (![#uint32T] "x") in
-    (func_call #primitive.primitive #"UInt32Put"%go) "$a0" "$a1")).
+    (func_call #primitive.primitive #"UInt32Put"%go) "$a0" "$a1");;;
+    return: #()).
 
 Definition Dec : go_type := structT [
   "p" :: sliceT
@@ -877,7 +893,8 @@ Definition forRangeNoBinding : val :=
     slice.for_range #stringT "$range" (λ: "$key" "$value",
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #"slice'"%go (![#sliceT] "x")) in
       slice.literal #interfaceT ["$sl0"])) in
-      (func_call #fmt.fmt #"Print"%go) "$a0"))).
+      (func_call #fmt.fmt #"Print"%go) "$a0"));;;
+    return: #()).
 
 (* go: for_range.go:11:6 *)
 Definition forRangeOldVars : val :=
@@ -892,7 +909,8 @@ Definition forRangeOldVars : val :=
       do:  "$key";;;
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go (![#stringT] "y")) in
       slice.literal #interfaceT ["$sl0"])) in
-      (func_call #fmt.fmt #"Print"%go) "$a0"))).
+      (func_call #fmt.fmt #"Print"%go) "$a0"));;;
+    return: #()).
 
 (* go: globals.go:3:6 *)
 Definition foo : val :=
@@ -903,7 +921,8 @@ Definition foo : val :=
 Definition other : val :=
   rec: "other" <> :=
     exception_do (let: "$r0" := #"ok"%go in
-    do:  ((globals.get #unittest.unittest #"globalY"%go) <-[#stringT] "$r0")).
+    do:  ((globals.get #unittest.unittest #"globalY"%go) <-[#stringT] "$r0");;;
+    return: #()).
 
 (* go: globals.go:18:6 *)
 Definition bar : val :=
@@ -913,13 +932,15 @@ Definition bar : val :=
     then
       do:  (let: "$a0" := (interface.make #""%go #"string"%go #"bad"%go) in
       Panic "$a0")
-    else do:  #())).
+    else do:  #());;;
+    return: #()).
 
 (* go: higher_order.go:3:6 *)
 Definition TakesFunctionType : val :=
   rec: "TakesFunctionType" "f" :=
     exception_do (let: "f" := (mem.alloc "f") in
-    do:  ((![#funcT] "f") #())).
+    do:  ((![#funcT] "f") #());;;
+    return: #()).
 
 Definition Fooer : go_type := interfaceT.
 
@@ -941,7 +962,8 @@ Definition concreteFooer__Foo : val :=
 Definition fooConsumer : val :=
   rec: "fooConsumer" "f" :=
     exception_do (let: "f" := (mem.alloc "f") in
-    do:  ((interface.get #"Foo"%go (![#Fooer] "f")) #())).
+    do:  ((interface.get #"Foo"%go (![#Fooer] "f")) #());;;
+    return: #()).
 
 (* go: interfaces.go:22:6 *)
 Definition testAssignConcreteToInterface : val :=
@@ -953,7 +975,8 @@ Definition testAssignConcreteToInterface : val :=
     }])) in
     do:  ("c" <-[#ptrT] "$r0");;;
     let: "$r0" := (interface.make #unittest.unittest #"concreteFooer'ptr" (![#ptrT] "c")) in
-    do:  ((![#ptrT] "x") <-[#Fooer] "$r0")).
+    do:  ((![#ptrT] "x") <-[#Fooer] "$r0");;;
+    return: #()).
 
 (* go: interfaces.go:27:6 *)
 Definition testPassConcreteToInterfaceArg : val :=
@@ -971,7 +994,8 @@ Definition testPassConcreteToInterfaceArg : val :=
     do:  (let: "$a0" := (![#Fooer] "f") in
     (func_call #unittest.unittest #"fooConsumer"%go) "$a0");;;
     do:  ((method_call #unittest.unittest #"concreteFooer'ptr" #"Foo" (![#ptrT] "c")) #());;;
-    do:  ((interface.get #"Foo"%go (![#Fooer] "f")) #())).
+    do:  ((interface.get #"Foo"%go (![#Fooer] "f")) #());;;
+    return: #()).
 
 (* go: interfaces.go:37:6 *)
 Definition testPassConcreteToInterfaceArgSpecial : val :=
@@ -1007,7 +1031,8 @@ Definition testPassConcreteToInterfaceArgSpecial : val :=
 Definition takesVarArgsInterface : val :=
   rec: "takesVarArgsInterface" "fs" :=
     exception_do (let: "fs" := (mem.alloc "fs") in
-    do:  ((interface.get #"Foo"%go (![#Fooer] (slice.elem_ref #Fooer (![#sliceT] "fs") #(W64 0)))) #())).
+    do:  ((interface.get #"Foo"%go (![#Fooer] (slice.elem_ref #Fooer (![#sliceT] "fs") #(W64 0)))) #());;;
+    return: #()).
 
 (* go: interfaces.go:55:6 *)
 Definition test : val :=
@@ -1019,7 +1044,8 @@ Definition test : val :=
       "a" ::= type.zero_val #uint64T
     }]))) in
     slice.literal #Fooer ["$sl0"; "$sl1"])) in
-    (func_call #unittest.unittest #"takesVarArgsInterface"%go) "$a0")).
+    (func_call #unittest.unittest #"takesVarArgsInterface"%go) "$a0");;;
+    return: #()).
 
 (* go: interfaces.go:59:6 *)
 Definition returnConcrete : val :=
@@ -1097,7 +1123,8 @@ Definition testConversionInMultiplePassThrough : val :=
     let: "$a1" := ((let: "$sl0" := "$ret1" in
     let: "$sl1" := (interface.make #unittest.unittest #"concreteFooer'ptr" "$ret2") in
     slice.literal #Fooer ["$sl0"; "$sl1"])) in
-    (func_call #unittest.unittest #"takeMultiple"%go) "$a0" "$a1")).
+    (func_call #unittest.unittest #"takeMultiple"%go) "$a0" "$a1");;;
+    return: #()).
 
 Definition PointerInterface : go_type := interfaceT.
 
@@ -1130,7 +1157,8 @@ Definition testPtrMset : val :=
     let: "$r0" := (interface.make #unittest.unittest #"concrete1" (![#concrete1] (![#ptrT] "a"))) in
     do:  ("f" <-[#Fooer] "$r0");;;
     do:  ((interface.get #"B"%go (![#PointerInterface] "p")) #());;;
-    do:  ((interface.get #"Foo"%go (![#Fooer] "f")) #())).
+    do:  ((interface.get #"Foo"%go (![#Fooer] "f")) #());;;
+    return: #()).
 
 (* go: ints.go:3:6 *)
 Definition useInts : val :=
@@ -1223,7 +1251,8 @@ Definition useLocks : val :=
     let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("m" <-[#ptrT] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "m")) #());;;
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "m")) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "m")) #());;;
+    return: #()).
 
 (* go: locks.go:11:6 *)
 Definition useCondVar : val :=
@@ -1238,7 +1267,8 @@ Definition useCondVar : val :=
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "m")) #());;;
     do:  ((method_call #sync #"Cond'ptr" #"Signal" (![#ptrT] "c")) #());;;
     do:  ((method_call #sync #"Cond'ptr" #"Wait" (![#ptrT] "c")) #());;;
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "m")) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "m")) #());;;
+    return: #()).
 
 Definition hasCondVar : go_type := structT [
   "cond" :: ptrT
@@ -1265,7 +1295,8 @@ Definition DoNothing : val :=
   rec: "DoNothing" <> :=
     exception_do (do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"doing nothing"%go) in
     slice.literal #interfaceT ["$sl0"])) in
-    (func_call #log.log #"Println"%go) "$a0")).
+    (func_call #log.log #"Println"%go) "$a0");;;
+    return: #()).
 
 (* DoSomething is an impure function
 
@@ -1324,7 +1355,8 @@ Definition conditionalInLoop : val :=
       else do:  #());;;
       let: "$r0" := ((![#uint64T] "i") + #(W64 1)) in
       do:  ("i" <-[#uint64T] "$r0");;;
-      continue: #()))).
+      continue: #()));;;
+    return: #()).
 
 (* go: loops.go:38:6 *)
 Definition conditionalInLoopElse : val :=
@@ -1338,7 +1370,8 @@ Definition conditionalInLoopElse : val :=
       else
         let: "$r0" := ((![#uint64T] "i") + #(W64 1)) in
         do:  ("i" <-[#uint64T] "$r0");;;
-        continue: #())))).
+        continue: #())));;;
+    return: #()).
 
 (* go: loops.go:49:6 *)
 Definition nestedConditionalInLoopImplicitContinue : val :=
@@ -1355,7 +1388,8 @@ Definition nestedConditionalInLoopImplicitContinue : val :=
       else
         let: "$r0" := ((![#uint64T] "i") + #(W64 1)) in
         do:  ("i" <-[#uint64T] "$r0");;;
-        continue: #())))).
+        continue: #())));;;
+    return: #()).
 
 (* go: loops.go:62:6 *)
 Definition ImplicitLoopContinue : val :=
@@ -1368,7 +1402,8 @@ Definition ImplicitLoopContinue : val :=
       then
         let: "$r0" := #(W64 0) in
         do:  ("i" <-[#uint64T] "$r0")
-      else do:  #())))).
+      else do:  #())));;;
+    return: #()).
 
 (* go: loops.go:70:6 *)
 Definition ImplicitLoopContinue2 : val :=
@@ -1382,7 +1417,8 @@ Definition ImplicitLoopContinue2 : val :=
         let: "$r0" := #(W64 0) in
         do:  ("i" <-[#uint64T] "$r0");;;
         continue: #()
-      else do:  #())))).
+      else do:  #())));;;
+    return: #()).
 
 (* go: loops.go:79:6 *)
 Definition ImplicitLoopContinueAfterIfBreak : val :=
@@ -1391,7 +1427,8 @@ Definition ImplicitLoopContinueAfterIfBreak : val :=
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       (if: (![#uint64T] "i") > #(W64 0)
       then break: #()
-      else do:  #()))).
+      else do:  #()));;;
+    return: #()).
 
 (* go: loops.go:87:6 *)
 Definition nestedLoops : val :=
@@ -1412,7 +1449,8 @@ Definition nestedLoops : val :=
         continue: #()));;;
       let: "$r0" := ((![#uint64T] "i") + #(W64 1)) in
       do:  ("i" <-[#uint64T] "$r0");;;
-      continue: #()))).
+      continue: #()));;;
+    return: #()).
 
 (* go: loops.go:101:6 *)
 Definition nestedGoStyleLoops : val :=
@@ -1428,7 +1466,8 @@ Definition nestedGoStyleLoops : val :=
         (if: #true
         then break: #()
         else do:  #());;;
-        continue: #()))))).
+        continue: #()))));;;
+    return: #()).
 
 (* go: loops.go:113:6 *)
 Definition sumSlice : val :=
@@ -1450,7 +1489,8 @@ Definition breakFromLoop : val :=
       (if: #true
       then break: #()
       else do:  #());;;
-      continue: #())).
+      continue: #());;;
+    return: #()).
 
 (* go: maps.go:3:6 *)
 Definition IterateMapKeys : val :=
@@ -1465,7 +1505,8 @@ Definition IterateMapKeys : val :=
       let: "$r0" := (![#uint64T] (![#ptrT] "sum")) in
       do:  ("oldSum" <-[#uint64T] "$r0");;;
       let: "$r0" := ((![#uint64T] "oldSum") + (![#uint64T] "k")) in
-      do:  ((![#ptrT] "sum") <-[#uint64T] "$r0")))).
+      do:  ((![#ptrT] "sum") <-[#uint64T] "$r0")));;;
+    return: #()).
 
 (* go: maps.go:10:6 *)
 Definition MapSize : val :=
@@ -1484,7 +1525,8 @@ Definition MapTypeAliases : val :=
     exception_do (let: "m2" := (mem.alloc "m2") in
     let: "m1" := (mem.alloc "m1") in
     let: "$r0" := (Fst (map.get (![#MapWrapper] "m2") #(W64 0))) in
-    do:  (map.insert (![type.mapT #IntWrapper #boolT] "m1") #(W64 4) "$r0")).
+    do:  (map.insert (![type.mapT #IntWrapper #boolT] "m1") #(W64 4) "$r0");;;
+    return: #()).
 
 (* go: maps.go:22:6 *)
 Definition StringMap : val :=
@@ -1504,7 +1546,8 @@ Definition mapUpdateField : val :=
     let: "$r0" := (map.make #uint64T #ptrT) in
     do:  ("x" <-[type.mapT #uint64T #ptrT] "$r0");;;
     let: "$r0" := #(W64 10) in
-    do:  ((struct.field_ref #mapElem #"a"%go (Fst (map.get (![type.mapT #uint64T #ptrT] "x") #(W64 0)))) <-[#uint64T] "$r0")).
+    do:  ((struct.field_ref #mapElem #"a"%go (Fst (map.get (![type.mapT #uint64T #ptrT] "x") #(W64 0)))) <-[#uint64T] "$r0");;;
+    return: #()).
 
 (* go: multiple.go:3:6 *)
 Definition returnTwo : val :=
@@ -1540,7 +1583,8 @@ Definition multiplePassThrough : val :=
     (func_call #unittest.unittest #"returnTwoWrapper"%go) "$a0")) in
     let: "$a0" := "$ret0" in
     let: "$a1" := "$ret1" in
-    (func_call #unittest.unittest #"multipleVar"%go) "$a0" "$a1")).
+    (func_call #unittest.unittest #"multipleVar"%go) "$a0" "$a1");;;
+    return: #()).
 
 (* go: multiple.go:18:6 *)
 Definition multipleReturnPassThrough : val :=
@@ -1556,7 +1600,8 @@ Definition AssignNilSlice : val :=
     let: "$r0" := (slice.make2 #sliceT #(W64 4)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     let: "$r0" := #slice.nil in
-    do:  ((slice.elem_ref #sliceT (![#sliceT] "s") #(W64 2)) <-[#sliceT] "$r0")).
+    do:  ((slice.elem_ref #sliceT (![#sliceT] "s") #(W64 2)) <-[#sliceT] "$r0");;;
+    return: #()).
 
 (* go: nil.go:8:6 *)
 Definition AssignNilPointer : val :=
@@ -1565,7 +1610,8 @@ Definition AssignNilPointer : val :=
     let: "$r0" := (slice.make2 #ptrT #(W64 4)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     let: "$r0" := #null in
-    do:  ((slice.elem_ref #ptrT (![#sliceT] "s") #(W64 2)) <-[#ptrT] "$r0")).
+    do:  ((slice.elem_ref #ptrT (![#sliceT] "s") #(W64 2)) <-[#ptrT] "$r0");;;
+    return: #()).
 
 (* go: nil.go:13:6 *)
 Definition CompareSliceToNil : val :=
@@ -1640,7 +1686,8 @@ Definition AssignOps : val :=
     do:  ("x" <-[#uint64T] ((![#uint64T] "x") + #(W64 3)));;;
     do:  ("x" <-[#uint64T] ((![#uint64T] "x") - #(W64 3)));;;
     do:  ("x" <-[#uint64T] ((![#uint64T] "x") + #(W64 1)));;;
-    do:  ("x" <-[#uint64T] ((![#uint64T] "x") - #(W64 1)))).
+    do:  ("x" <-[#uint64T] ((![#uint64T] "x") - #(W64 1)));;;
+    return: #()).
 
 (* go: operators.go:47:6 *)
 Definition Negative : val :=
@@ -1648,7 +1695,8 @@ Definition Negative : val :=
     exception_do (let: "x" := (mem.alloc (type.zero_val #int64T)) in
     let: "$r0" := #(W64 (- 10)) in
     do:  ("x" <-[#int64T] "$r0");;;
-    do:  ("x" <-[#int64T] ((![#int64T] "x") + #(W64 3)))).
+    do:  ("x" <-[#int64T] ((![#int64T] "x") + #(W64 3)));;;
+    return: #()).
 
 Definition wrapExternalStruct : go_type := structT [
   "j" :: ptrT
@@ -1658,13 +1706,15 @@ Definition wrapExternalStruct : go_type := structT [
 Definition wrapExternalStruct__join : val :=
   rec: "wrapExternalStruct__join" "w" <> :=
     exception_do (let: "w" := (mem.alloc "w") in
-    do:  ((method_call #std #"JoinHandle'ptr" #"Join" (![#ptrT] (struct.field_ref #wrapExternalStruct #"j"%go "w"))) #())).
+    do:  ((method_call #std #"JoinHandle'ptr" #"Join" (![#ptrT] (struct.field_ref #wrapExternalStruct #"j"%go "w"))) #());;;
+    return: #()).
 
 (* go: panic.go:3:6 *)
 Definition PanicAtTheDisco : val :=
   rec: "PanicAtTheDisco" <> :=
     exception_do (do:  (let: "$a0" := (interface.make #""%go #"string"%go #"disco"%go) in
-    Panic "$a0")).
+    Panic "$a0");;;
+    return: #()).
 
 (* go: proph.go:5:6 *)
 Definition Oracle : val :=
@@ -1673,7 +1723,8 @@ Definition Oracle : val :=
     let: "$r0" := ((func_call #primitive.primitive #"NewProph"%go) #()) in
     do:  ("p" <-[#ptrT] "$r0");;;
     let: "$r0" := (![#ptrT] "p") in
-    do:  ("p" <-[#ptrT] "$r0")).
+    do:  ("p" <-[#ptrT] "$r0");;;
+    return: #()).
 
 Definition typing : go_type := structT [
   "proph" :: ptrT
@@ -1709,12 +1760,14 @@ Definition ReassignVars : val :=
     }]) in
     do:  ("z" <-[#composite] "$r0");;;
     let: "$r0" := (![#uint64T] (struct.field_ref #composite #"a"%go "z")) in
-    do:  ("x" <-[#uint64T] "$r0")).
+    do:  ("x" <-[#uint64T] "$r0");;;
+    return: #()).
 
 (* go: recursive.go:3:6 *)
 Definition recur : val :=
   rec: "recur" <> :=
-    exception_do (do:  ((func_call #unittest.unittest #"recur"%go) #())).
+    exception_do (do:  ((func_call #unittest.unittest #"recur"%go) #());;;
+    return: #()).
 
 Definition R : go_type := structT [
 ].
@@ -1723,7 +1776,8 @@ Definition R : go_type := structT [
 Definition R__recurMethod : val :=
   rec: "R__recurMethod" "r" <> :=
     exception_do (let: "r" := (mem.alloc "r") in
-    do:  ((method_call #unittest.unittest #"R'ptr" #"recurMethod" (![#ptrT] "r")) #())).
+    do:  ((method_call #unittest.unittest #"R'ptr" #"recurMethod" (![#ptrT] "r")) #());;;
+    return: #()).
 
 Definition Other : go_type := structT [
   "RecursiveEmbedded" :: ptrT
@@ -1737,14 +1791,16 @@ Definition RecursiveEmbedded : go_type := structT [
 Definition RecursiveEmbedded__recurEmbeddedMethod : val :=
   rec: "RecursiveEmbedded__recurEmbeddedMethod" "r" <> :=
     exception_do (let: "r" := (mem.alloc "r") in
-    do:  ((method_call #unittest.unittest #"Other" #"recurEmbeddedMethod" (![#Other] (struct.field_ref #RecursiveEmbedded #"Other"%go (![#ptrT] "r")))) #())).
+    do:  ((method_call #unittest.unittest #"Other" #"recurEmbeddedMethod" (![#Other] (struct.field_ref #RecursiveEmbedded #"Other"%go (![#ptrT] "r")))) #());;;
+    return: #()).
 
 (* go: renamedImport.go:7:6 *)
 Definition useRenamedImport : val :=
   rec: "useRenamedImport" <> :=
     exception_do (do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"blah"%go) in
     slice.literal #interfaceT ["$sl0"])) in
-    (func_call #fmt.fmt #"Print"%go) "$a0")).
+    (func_call #fmt.fmt #"Print"%go) "$a0");;;
+    return: #()).
 
 Definition Block : go_type := structT [
   "Value" :: uint64T
@@ -1845,7 +1901,8 @@ Definition ReplicatedDiskWrite : val :=
     let: "$a2" := (![#Block] "v") in
     (func_call #unittest.unittest #"TwoDiskWrite"%go) "$a0" "$a1" "$a2");;;
     do:  (let: "$a0" := (![#uint64T] "a") in
-    (func_call #unittest.unittest #"TwoDiskUnlock"%go) "$a0")).
+    (func_call #unittest.unittest #"TwoDiskUnlock"%go) "$a0");;;
+    return: #()).
 
 (* go: replicated_disk.go:49:6 *)
 Definition ReplicatedDiskRecover : val :=
@@ -1875,7 +1932,8 @@ Definition ReplicatedDiskRecover : val :=
       else do:  #());;;
       let: "$r0" := ((![#uint64T] "a") + #(W64 1)) in
       do:  ("a" <-[#uint64T] "$r0");;;
-      continue: #()))).
+      continue: #()));;;
+    return: #()).
 
 (* go: returns.go:3:6 *)
 Definition BasicNamedReturn : val :=
@@ -1923,6 +1981,20 @@ Definition NamedReturnOverride : val :=
       do:  ("y" <-[#stringT] "$r0");;;
       break: #());;;
     return: (![#stringT] "x", ![#stringT] "y")).
+
+(* go: returns.go:32:6 *)
+Definition VoidButEndsWithReturn : val :=
+  rec: "VoidButEndsWithReturn" <> :=
+    exception_do (do:  ((func_call #unittest.unittest #"BasicNamedReturn"%go) #());;;
+    return: #()).
+
+(* go: returns.go:38:6 *)
+Definition VoidImplicitReturnInBranch : val :=
+  rec: "VoidImplicitReturnInBranch" <> :=
+    exception_do ((if: #true
+    then return: (#())
+    else do:  ((func_call #unittest.unittest #"BasicNamedReturn"%go) #()));;;
+    return: #()).
 
 Definition SliceAlias : go_type := sliceT.
 
@@ -2001,13 +2073,15 @@ Definition simpleSpawn : val :=
       (if: (![#uint64T] "x") > #(W64 0)
       then do:  ((func_call #unittest.unittest #"Skip"%go) #())
       else do:  #());;;
-      do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "l")) #()))
+      do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "l")) #());;;
+      return: #())
       ) in
     do:  (Fork ("$go" #()));;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "l")) #());;;
     let: "$r0" := #(W64 1) in
     do:  ((![#ptrT] "v") <-[#uint64T] "$r0");;;
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "l")) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "l")) #());;;
+    return: #()).
 
 (* go: spawn.go:26:6 *)
 Definition threadCode : val :=
@@ -2027,7 +2101,8 @@ Definition loopSpawn : val :=
       do:  ("i" <-[#uint64T] "$r0");;;
       let: "$go" := (λ: <>,
         exception_do (do:  (let: "$a0" := (![#uint64T] "i") in
-        (func_call #unittest.unittest #"threadCode"%go) "$a0"))
+        (func_call #unittest.unittest #"threadCode"%go) "$a0");;;
+        return: #())
         ) in
       do:  (Fork ("$go" #()))));;;
     (let: "dummy" := (mem.alloc (type.zero_val #boolT)) in
@@ -2036,7 +2111,8 @@ Definition loopSpawn : val :=
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       let: "$r0" := (~ (![#boolT] "dummy")) in
       do:  ("dummy" <-[#boolT] "$r0");;;
-      continue: #()))).
+      continue: #()));;;
+    return: #()).
 
 (* go: strings.go:3:6 *)
 Definition stringAppend : val :=
@@ -2055,7 +2131,8 @@ Definition stringLength : val :=
 Definition x : val :=
   rec: "x" <> :=
     exception_do (do:  (let: "$a0" := #("a"%go ++ "b"%go) in
-    (func_call #unittest.unittest #"stringAppend"%go) "$a0")).
+    (func_call #unittest.unittest #"stringAppend"%go) "$a0");;;
+    return: #()).
 
 Definition Point : go_type := structT [
   "x" :: uint64T;
@@ -2164,14 +2241,16 @@ Definition S__writeB : val :=
     exception_do (let: "s" := (mem.alloc "s") in
     let: "two" := (mem.alloc "two") in
     let: "$r0" := (![#TwoInts] "two") in
-    do:  ((struct.field_ref #S #"b"%go (![#ptrT] "s")) <-[#TwoInts] "$r0")).
+    do:  ((struct.field_ref #S #"b"%go (![#ptrT] "s")) <-[#TwoInts] "$r0");;;
+    return: #()).
 
 (* go: struct_pointers.go:38:13 *)
 Definition S__negateC : val :=
   rec: "S__negateC" "s" <> :=
     exception_do (let: "s" := (mem.alloc "s") in
     let: "$r0" := (~ (![#boolT] (struct.field_ref #S #"c"%go (![#ptrT] "s")))) in
-    do:  ((struct.field_ref #S #"c"%go (![#ptrT] "s")) <-[#boolT] "$r0")).
+    do:  ((struct.field_ref #S #"c"%go (![#ptrT] "s")) <-[#boolT] "$r0");;;
+    return: #()).
 
 (* go: struct_pointers.go:42:13 *)
 Definition S__refC : val :=
@@ -2202,7 +2281,8 @@ Definition DoSomeLocking : val :=
   rec: "DoSomeLocking" "l" :=
     exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "l")) #());;;
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "l")) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "l")) #());;;
+    return: #()).
 
 (* go: synchronization.go:15:6 *)
 Definition makeLock : val :=
@@ -2211,13 +2291,15 @@ Definition makeLock : val :=
     let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("l" <-[#ptrT] "$r0");;;
     do:  (let: "$a0" := (![#ptrT] "l") in
-    (func_call #unittest.unittest #"DoSomeLocking"%go) "$a0")).
+    (func_call #unittest.unittest #"DoSomeLocking"%go) "$a0");;;
+    return: #()).
 
 (* go: time.go:5:6 *)
 Definition sleep : val :=
   rec: "sleep" <> :=
     exception_do (do:  (let: "$a0" := #(W64 1000) in
-    (func_call #primitive.primitive #"Sleep"%go) "$a0")).
+    (func_call #primitive.primitive #"Sleep"%go) "$a0");;;
+    return: #()).
 
 Definition B : go_type := structT [
   "a" :: sliceT
@@ -2234,7 +2316,8 @@ Definition mkInt : val :=
 (* go: trailing_call.go:7:6 *)
 Definition mkNothing : val :=
   rec: "mkNothing" <> :=
-    exception_do (do:  ((func_call #unittest.unittest #"mkInt"%go) #())).
+    exception_do (do:  ((func_call #unittest.unittest #"mkInt"%go) #());;;
+    return: #()).
 
 Definition my_u64 : go_type := uint64T.
 
@@ -2279,7 +2362,8 @@ Definition testVariadicCall : val :=
     do:  (let: "$a0" := #(W64 10) in
     let: "$a1" := #"abc"%go in
     let: "$a2" := (![#sliceT] "c") in
-    (func_call #unittest.unittest #"variadicFunc"%go) "$a0" "$a1" "$a2")).
+    (func_call #unittest.unittest #"variadicFunc"%go) "$a0" "$a1" "$a2");;;
+    return: #()).
 
 (* go: varargs.go:13:6 *)
 Definition returnMultiple : val :=
@@ -2295,11 +2379,12 @@ Definition testVariadicPassThrough : val :=
     let: "$a2" := ((let: "$sl0" := "$ret2" in
     let: "$sl1" := "$ret3" in
     slice.literal #byteT ["$sl0"; "$sl1"])) in
-    (func_call #unittest.unittest #"variadicFunc"%go) "$a0" "$a1" "$a2")).
+    (func_call #unittest.unittest #"variadicFunc"%go) "$a0" "$a1" "$a2");;;
+    return: #()).
 
 Definition vars' : list (go_string * go_type) := [("GlobalX"%go, uint64T); ("globalY"%go, stringT); ("globalA"%go, stringT); ("globalB"%go, stringT); ("mapLiteral"%go, mapT stringT uint64T); ("mapLiteralWithConversion"%go, mapT interfaceT interfaceT)].
 
-Definition functions' : list (go_string * val) := [("takesArray"%go, takesArray); ("takesPtr"%go, takesPtr); ("usesArrayElemRef"%go, usesArrayElemRef); ("sum"%go, sum); ("arrayToSlice"%go, arrayToSlice); ("arrayLiteralKeyed"%go, arrayLiteralKeyed); ("chanBasic"%go, chanBasic); ("f"%go, f); ("chanSelect"%go, chanSelect); ("chanDirectional"%go, chanDirectional); ("chanRange"%go, chanRange); ("doSubtleThings"%go, doSubtleThings); ("hasStartComment"%go, hasStartComment); ("hasEndComment"%go, hasEndComment); ("condvarWrapping"%go, condvarWrapping); ("useUntypedInt"%go, useUntypedInt); ("useUntypedString"%go, useUntypedString); ("conditionalReturn"%go, conditionalReturn); ("alwaysReturn"%go, alwaysReturn); ("alwaysReturnInNestedBranches"%go, alwaysReturnInNestedBranches); ("earlyReturn"%go, earlyReturn); ("conditionalAssign"%go, conditionalAssign); ("elseIf"%go, elseIf); ("ifStmtInitialization"%go, ifStmtInitialization); ("typedLiteral"%go, typedLiteral); ("literalCast"%go, literalCast); ("castInt"%go, castInt); ("stringToByteSlice"%go, stringToByteSlice); ("byteSliceToString"%go, byteSliceToString); ("stringToStringWrapper"%go, stringToStringWrapper); ("stringWrapperToString"%go, stringWrapperToString); ("testCopySimple"%go, testCopySimple); ("testCopyDifferentLengths"%go, testCopyDifferentLengths); ("atomicCreateStub"%go, atomicCreateStub); ("useSlice"%go, useSlice); ("useSliceIndexing"%go, useSliceIndexing); ("useMap"%go, useMap); ("usePtr"%go, usePtr); ("iterMapKeysAndValues"%go, iterMapKeysAndValues); ("iterMapKeys"%go, iterMapKeys); ("getRandom"%go, getRandom); ("diskArgument"%go, diskArgument); ("returnEmbedVal"%go, returnEmbedVal); ("returnEmbedValWithPointer"%go, returnEmbedValWithPointer); ("useEmbeddedField"%go, useEmbeddedField); ("useEmbeddedValField"%go, useEmbeddedValField); ("useEmbeddedMethod"%go, useEmbeddedMethod); ("useEmbeddedMethod2"%go, useEmbeddedMethod2); ("empty"%go, empty); ("emptyReturn"%go, emptyReturn); ("unnamedParams"%go, unnamedParams); ("anonymousParam"%go, anonymousParam); ("forRangeNoBinding"%go, forRangeNoBinding); ("forRangeOldVars"%go, forRangeOldVars); ("foo"%go, foo); ("other"%go, other); ("bar"%go, bar); ("TakesFunctionType"%go, TakesFunctionType); ("fooConsumer"%go, fooConsumer); ("testAssignConcreteToInterface"%go, testAssignConcreteToInterface); ("testPassConcreteToInterfaceArg"%go, testPassConcreteToInterfaceArg); ("testPassConcreteToInterfaceArgSpecial"%go, testPassConcreteToInterfaceArgSpecial); ("takesVarArgsInterface"%go, takesVarArgsInterface); ("test"%go, test); ("returnConcrete"%go, returnConcrete); ("testMultiReturn"%go, testMultiReturn); ("testReturnStatment"%go, testReturnStatment); ("testConversionInEq"%go, testConversionInEq); ("takeMultiple"%go, takeMultiple); ("giveMultiple"%go, giveMultiple); ("testConversionInMultipleReturnPassThrough"%go, testConversionInMultipleReturnPassThrough); ("testConversionInMultiplePassThrough"%go, testConversionInMultiplePassThrough); ("testPtrMset"%go, testPtrMset); ("useInts"%go, useInts); ("normalLiterals"%go, normalLiterals); ("outOfOrderLiteral"%go, outOfOrderLiteral); ("specialLiterals"%go, specialLiterals); ("oddLiterals"%go, oddLiterals); ("unKeyedLiteral"%go, unKeyedLiteral); ("useLocks"%go, useLocks); ("useCondVar"%go, useCondVar); ("ToBeDebugged"%go, ToBeDebugged); ("DoNothing"%go, DoNothing); ("DoSomething"%go, DoSomething); ("standardForLoop"%go, standardForLoop); ("conditionalInLoop"%go, conditionalInLoop); ("conditionalInLoopElse"%go, conditionalInLoopElse); ("nestedConditionalInLoopImplicitContinue"%go, nestedConditionalInLoopImplicitContinue); ("ImplicitLoopContinue"%go, ImplicitLoopContinue); ("ImplicitLoopContinue2"%go, ImplicitLoopContinue2); ("ImplicitLoopContinueAfterIfBreak"%go, ImplicitLoopContinueAfterIfBreak); ("nestedLoops"%go, nestedLoops); ("nestedGoStyleLoops"%go, nestedGoStyleLoops); ("sumSlice"%go, sumSlice); ("breakFromLoop"%go, breakFromLoop); ("IterateMapKeys"%go, IterateMapKeys); ("MapSize"%go, MapSize); ("MapTypeAliases"%go, MapTypeAliases); ("StringMap"%go, StringMap); ("mapUpdateField"%go, mapUpdateField); ("returnTwo"%go, returnTwo); ("returnTwoWrapper"%go, returnTwoWrapper); ("multipleVar"%go, multipleVar); ("multiplePassThrough"%go, multiplePassThrough); ("multipleReturnPassThrough"%go, multipleReturnPassThrough); ("AssignNilSlice"%go, AssignNilSlice); ("AssignNilPointer"%go, AssignNilPointer); ("CompareSliceToNil"%go, CompareSliceToNil); ("ComparePointerToNil"%go, ComparePointerToNil); ("LogicalOperators"%go, LogicalOperators); ("LogicalAndEqualityOperators"%go, LogicalAndEqualityOperators); ("ArithmeticShifts"%go, ArithmeticShifts); ("BitwiseOps"%go, BitwiseOps); ("Comparison"%go, Comparison); ("AssignOps"%go, AssignOps); ("Negative"%go, Negative); ("PanicAtTheDisco"%go, PanicAtTheDisco); ("Oracle"%go, Oracle); ("ReassignVars"%go, ReassignVars); ("recur"%go, recur); ("useRenamedImport"%go, useRenamedImport); ("TwoDiskWrite"%go, TwoDiskWrite); ("TwoDiskRead"%go, TwoDiskRead); ("TwoDiskLock"%go, TwoDiskLock); ("TwoDiskUnlock"%go, TwoDiskUnlock); ("ReplicatedDiskRead"%go, ReplicatedDiskRead); ("ReplicatedDiskWrite"%go, ReplicatedDiskWrite); ("ReplicatedDiskRecover"%go, ReplicatedDiskRecover); ("BasicNamedReturn"%go, BasicNamedReturn); ("NamedReturn"%go, NamedReturn); ("BasicNamedReturnMany"%go, BasicNamedReturnMany); ("NamedReturnMany"%go, NamedReturnMany); ("NamedReturnOverride"%go, NamedReturnOverride); ("sliceOps"%go, sliceOps); ("makeSingletonSlice"%go, makeSingletonSlice); ("makeAlias"%go, makeAlias); ("Skip"%go, Skip); ("simpleSpawn"%go, simpleSpawn); ("threadCode"%go, threadCode); ("loopSpawn"%go, loopSpawn); ("stringAppend"%go, stringAppend); ("stringLength"%go, stringLength); ("x"%go, x); ("UseAdd"%go, UseAdd); ("UseAddWithLiteral"%go, UseAddWithLiteral); ("NewS"%go, NewS); ("localSRef"%go, localSRef); ("setField"%go, setField); ("DoSomeLocking"%go, DoSomeLocking); ("makeLock"%go, makeLock); ("sleep"%go, sleep); ("mkInt"%go, mkInt); ("mkNothing"%go, mkNothing); ("convertToAlias"%go, convertToAlias); ("variadicFunc"%go, variadicFunc); ("testVariadicCall"%go, testVariadicCall); ("returnMultiple"%go, returnMultiple); ("testVariadicPassThrough"%go, testVariadicPassThrough)].
+Definition functions' : list (go_string * val) := [("takesArray"%go, takesArray); ("takesPtr"%go, takesPtr); ("usesArrayElemRef"%go, usesArrayElemRef); ("sum"%go, sum); ("arrayToSlice"%go, arrayToSlice); ("arrayLiteralKeyed"%go, arrayLiteralKeyed); ("chanBasic"%go, chanBasic); ("f"%go, f); ("chanSelect"%go, chanSelect); ("chanDirectional"%go, chanDirectional); ("chanRange"%go, chanRange); ("doSubtleThings"%go, doSubtleThings); ("hasStartComment"%go, hasStartComment); ("hasEndComment"%go, hasEndComment); ("condvarWrapping"%go, condvarWrapping); ("useUntypedInt"%go, useUntypedInt); ("useUntypedString"%go, useUntypedString); ("conditionalReturn"%go, conditionalReturn); ("alwaysReturn"%go, alwaysReturn); ("alwaysReturnInNestedBranches"%go, alwaysReturnInNestedBranches); ("earlyReturn"%go, earlyReturn); ("conditionalAssign"%go, conditionalAssign); ("elseIf"%go, elseIf); ("ifStmtInitialization"%go, ifStmtInitialization); ("typedLiteral"%go, typedLiteral); ("literalCast"%go, literalCast); ("castInt"%go, castInt); ("stringToByteSlice"%go, stringToByteSlice); ("byteSliceToString"%go, byteSliceToString); ("stringToStringWrapper"%go, stringToStringWrapper); ("stringWrapperToString"%go, stringWrapperToString); ("testCopySimple"%go, testCopySimple); ("testCopyDifferentLengths"%go, testCopyDifferentLengths); ("atomicCreateStub"%go, atomicCreateStub); ("useSlice"%go, useSlice); ("useSliceIndexing"%go, useSliceIndexing); ("useMap"%go, useMap); ("usePtr"%go, usePtr); ("iterMapKeysAndValues"%go, iterMapKeysAndValues); ("iterMapKeys"%go, iterMapKeys); ("getRandom"%go, getRandom); ("diskArgument"%go, diskArgument); ("returnEmbedVal"%go, returnEmbedVal); ("returnEmbedValWithPointer"%go, returnEmbedValWithPointer); ("useEmbeddedField"%go, useEmbeddedField); ("useEmbeddedValField"%go, useEmbeddedValField); ("useEmbeddedMethod"%go, useEmbeddedMethod); ("useEmbeddedMethod2"%go, useEmbeddedMethod2); ("empty"%go, empty); ("emptyReturn"%go, emptyReturn); ("unnamedParams"%go, unnamedParams); ("anonymousParam"%go, anonymousParam); ("forRangeNoBinding"%go, forRangeNoBinding); ("forRangeOldVars"%go, forRangeOldVars); ("foo"%go, foo); ("other"%go, other); ("bar"%go, bar); ("TakesFunctionType"%go, TakesFunctionType); ("fooConsumer"%go, fooConsumer); ("testAssignConcreteToInterface"%go, testAssignConcreteToInterface); ("testPassConcreteToInterfaceArg"%go, testPassConcreteToInterfaceArg); ("testPassConcreteToInterfaceArgSpecial"%go, testPassConcreteToInterfaceArgSpecial); ("takesVarArgsInterface"%go, takesVarArgsInterface); ("test"%go, test); ("returnConcrete"%go, returnConcrete); ("testMultiReturn"%go, testMultiReturn); ("testReturnStatment"%go, testReturnStatment); ("testConversionInEq"%go, testConversionInEq); ("takeMultiple"%go, takeMultiple); ("giveMultiple"%go, giveMultiple); ("testConversionInMultipleReturnPassThrough"%go, testConversionInMultipleReturnPassThrough); ("testConversionInMultiplePassThrough"%go, testConversionInMultiplePassThrough); ("testPtrMset"%go, testPtrMset); ("useInts"%go, useInts); ("normalLiterals"%go, normalLiterals); ("outOfOrderLiteral"%go, outOfOrderLiteral); ("specialLiterals"%go, specialLiterals); ("oddLiterals"%go, oddLiterals); ("unKeyedLiteral"%go, unKeyedLiteral); ("useLocks"%go, useLocks); ("useCondVar"%go, useCondVar); ("ToBeDebugged"%go, ToBeDebugged); ("DoNothing"%go, DoNothing); ("DoSomething"%go, DoSomething); ("standardForLoop"%go, standardForLoop); ("conditionalInLoop"%go, conditionalInLoop); ("conditionalInLoopElse"%go, conditionalInLoopElse); ("nestedConditionalInLoopImplicitContinue"%go, nestedConditionalInLoopImplicitContinue); ("ImplicitLoopContinue"%go, ImplicitLoopContinue); ("ImplicitLoopContinue2"%go, ImplicitLoopContinue2); ("ImplicitLoopContinueAfterIfBreak"%go, ImplicitLoopContinueAfterIfBreak); ("nestedLoops"%go, nestedLoops); ("nestedGoStyleLoops"%go, nestedGoStyleLoops); ("sumSlice"%go, sumSlice); ("breakFromLoop"%go, breakFromLoop); ("IterateMapKeys"%go, IterateMapKeys); ("MapSize"%go, MapSize); ("MapTypeAliases"%go, MapTypeAliases); ("StringMap"%go, StringMap); ("mapUpdateField"%go, mapUpdateField); ("returnTwo"%go, returnTwo); ("returnTwoWrapper"%go, returnTwoWrapper); ("multipleVar"%go, multipleVar); ("multiplePassThrough"%go, multiplePassThrough); ("multipleReturnPassThrough"%go, multipleReturnPassThrough); ("AssignNilSlice"%go, AssignNilSlice); ("AssignNilPointer"%go, AssignNilPointer); ("CompareSliceToNil"%go, CompareSliceToNil); ("ComparePointerToNil"%go, ComparePointerToNil); ("LogicalOperators"%go, LogicalOperators); ("LogicalAndEqualityOperators"%go, LogicalAndEqualityOperators); ("ArithmeticShifts"%go, ArithmeticShifts); ("BitwiseOps"%go, BitwiseOps); ("Comparison"%go, Comparison); ("AssignOps"%go, AssignOps); ("Negative"%go, Negative); ("PanicAtTheDisco"%go, PanicAtTheDisco); ("Oracle"%go, Oracle); ("ReassignVars"%go, ReassignVars); ("recur"%go, recur); ("useRenamedImport"%go, useRenamedImport); ("TwoDiskWrite"%go, TwoDiskWrite); ("TwoDiskRead"%go, TwoDiskRead); ("TwoDiskLock"%go, TwoDiskLock); ("TwoDiskUnlock"%go, TwoDiskUnlock); ("ReplicatedDiskRead"%go, ReplicatedDiskRead); ("ReplicatedDiskWrite"%go, ReplicatedDiskWrite); ("ReplicatedDiskRecover"%go, ReplicatedDiskRecover); ("BasicNamedReturn"%go, BasicNamedReturn); ("NamedReturn"%go, NamedReturn); ("BasicNamedReturnMany"%go, BasicNamedReturnMany); ("NamedReturnMany"%go, NamedReturnMany); ("NamedReturnOverride"%go, NamedReturnOverride); ("VoidButEndsWithReturn"%go, VoidButEndsWithReturn); ("VoidImplicitReturnInBranch"%go, VoidImplicitReturnInBranch); ("sliceOps"%go, sliceOps); ("makeSingletonSlice"%go, makeSingletonSlice); ("makeAlias"%go, makeAlias); ("Skip"%go, Skip); ("simpleSpawn"%go, simpleSpawn); ("threadCode"%go, threadCode); ("loopSpawn"%go, loopSpawn); ("stringAppend"%go, stringAppend); ("stringLength"%go, stringLength); ("x"%go, x); ("UseAdd"%go, UseAdd); ("UseAddWithLiteral"%go, UseAddWithLiteral); ("NewS"%go, NewS); ("localSRef"%go, localSRef); ("setField"%go, setField); ("DoSomeLocking"%go, DoSomeLocking); ("makeLock"%go, makeLock); ("sleep"%go, sleep); ("mkInt"%go, mkInt); ("mkNothing"%go, mkNothing); ("convertToAlias"%go, convertToAlias); ("variadicFunc"%go, variadicFunc); ("testVariadicCall"%go, testVariadicCall); ("returnMultiple"%go, returnMultiple); ("testVariadicPassThrough"%go, testVariadicPassThrough)].
 
 Definition msets' : list (go_string * (list (go_string * val))) := [("Foo"%go, []); ("Foo'ptr"%go, []); ("importantStruct"%go, []); ("importantStruct'ptr"%go, []); ("stringWrapper"%go, []); ("stringWrapper'ptr"%go, []); ("diskWrapper"%go, []); ("diskWrapper'ptr"%go, []); ("embedA"%go, [("Foo"%go, embedA__Foo)]); ("embedA'ptr"%go, [("Bar"%go, embedA__Bar); ("Foo"%go, (λ: "$recvAddr",
                  method_call #unittest.unittest #"embedA" #"Foo" (![#embedA] "$recvAddr")
@@ -2384,11 +2469,13 @@ Definition initialize' : val :=
       do:  ((globals.get #unittest.unittest #"mapLiteralWithConversion"%go) <-[type.mapT #interfaceT #interfaceT] "$r0");;;
       do:  ((λ: <>,
         exception_do (let: "$r0" := (![#uint64T] (globals.get #unittest.unittest #"GlobalX"%go)) in
-        do:  ((globals.get #unittest.unittest #"GlobalX"%go) <-[#uint64T] "$r0"))
+        do:  ((globals.get #unittest.unittest #"GlobalX"%go) <-[#uint64T] "$r0");;;
+        return: #())
         ) #());;;
       do:  ((λ: <>,
         exception_do (let: "$r0" := #""%go in
-        do:  ((globals.get #unittest.unittest #"globalY"%go) <-[#stringT] "$r0"))
+        do:  ((globals.get #unittest.unittest #"globalY"%go) <-[#stringT] "$r0");;;
+        return: #())
         ) #()))
       ).
 

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -1990,8 +1990,9 @@ Definition VoidButEndsWithReturn : val :=
 
 (* go: returns.go:38:6 *)
 Definition VoidImplicitReturnInBranch : val :=
-  rec: "VoidImplicitReturnInBranch" <> :=
-    exception_do ((if: #true
+  rec: "VoidImplicitReturnInBranch" "b" :=
+    exception_do (let: "b" := (mem.alloc "b") in
+    (if: ![#boolT] "b"
     then return: (#())
     else do:  ((func_call #unittest.unittest #"BasicNamedReturn"%go) #()));;;
     return: #()).

--- a/testdata/examples/wal/wal.gold.v
+++ b/testdata/examples/wal/wal.gold.v
@@ -94,13 +94,15 @@ Definition New : val :=
 Definition Log__lock : val :=
   rec: "Log__lock" "l" <> :=
     exception_do (let: "l" := (mem.alloc "l") in
-    do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #());;;
+    return: #()).
 
 (* go: log.go:56:14 *)
 Definition Log__unlock : val :=
   rec: "Log__unlock" "l" <> :=
     exception_do (let: "l" := (mem.alloc "l") in
-    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #())).
+    do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #());;;
+    return: #()).
 
 (* BeginTxn allocates space for a new transaction in the log.
 
@@ -194,7 +196,8 @@ Definition Log__Write : val :=
     do:  (map.insert (![type.mapT #uint64T #sliceT] (struct.field_ref #Log #"cache"%go "l")) (![#uint64T] "a") "$r0");;;
     let: "$r0" := ((![#uint64T] "length") + #(W64 1)) in
     do:  ((![#ptrT] (struct.field_ref #Log #"length"%go "l")) <-[#uint64T] "$r0");;;
-    do:  ((method_call #wal.awol #"Log" #"unlock" (![#Log] "l")) #())).
+    do:  ((method_call #wal.awol #"Log" #"unlock" (![#Log] "l")) #());;;
+    return: #()).
 
 (* Commit the current transaction.
 
@@ -213,7 +216,8 @@ Definition Log__Commit : val :=
     do:  ("header" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := (![#sliceT] "header") in
-    (interface.get #"Write"%go (![#disk.Disk] (struct.field_ref #Log #"d"%go "l"))) "$a0" "$a1")).
+    (interface.get #"Write"%go (![#disk.Disk] (struct.field_ref #Log #"d"%go "l"))) "$a0" "$a1");;;
+    return: #()).
 
 (* go: log.go:122:6 *)
 Definition getLogEntry : val :=
@@ -266,7 +270,8 @@ Definition applyLog : val :=
         do:  ("i" <-[#uint64T] "$r0");;;
         continue: #()
       else do:  #());;;
-      break: #()))).
+      break: #()));;;
+    return: #()).
 
 (* go: log.go:142:6 *)
 Definition clearLog : val :=
@@ -278,7 +283,8 @@ Definition clearLog : val :=
     do:  ("header" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := (![#sliceT] "header") in
-    (interface.get #"Write"%go (![#disk.Disk] "d")) "$a0" "$a1")).
+    (interface.get #"Write"%go (![#disk.Disk] "d")) "$a0" "$a1");;;
+    return: #()).
 
 (* Apply all the committed transactions.
 
@@ -299,7 +305,8 @@ Definition Log__Apply : val :=
     (func_call #wal.awol #"clearLog"%go) "$a0");;;
     let: "$r0" := #(W64 0) in
     do:  ((![#ptrT] (struct.field_ref #Log #"length"%go "l")) <-[#uint64T] "$r0");;;
-    do:  ((method_call #wal.awol #"Log" #"unlock" (![#Log] "l")) #())).
+    do:  ((method_call #wal.awol #"Log" #"unlock" (![#Log] "l")) #());;;
+    return: #()).
 
 (* Open recovers the log following a crash or shutdown
 


### PR DESCRIPTION
Fixes #101.

This is rarely needed but for simplicity and accuracy of translation we add it everywhere. It's hard to identify in which branches the implicit return from the last statement would already be a unit value.