### PR TITLE
Fix channel model select semantics

### DIFF
--- a/model/channel/channel_test.go
+++ b/model/channel/channel_test.go
@@ -1330,7 +1330,7 @@ func Test2NBSelectNoProgress(t *testing.T) {
 	doneRecv := make(chan struct{})
 	go func() {
 		for {
-			selected := channel.Select1(case_1 /*blocking=*/, false)
+			selected := channel.Select1(case_1, false)
 			if selected {
 				break
 			}
@@ -1342,7 +1342,7 @@ func Test2NBSelectNoProgress(t *testing.T) {
 	doneSend := make(chan struct{})
 	go func() {
 		for {
-			selected := channel.Select1(case_2 /*blocking=*/, false)
+			selected := channel.Select1(case_2, false)
 			if selected {
 				break
 			}


### PR DESCRIPTION
I mistakenly thought that 2 non-blocking selects could pair up, but this is not the case. The fix was to use the offer semantics only for blocking selects. This is not a significant semantic change but did require a decent amount of plumbing given how much modularity there is here. 

Added a test to make sure this WAI. 