### PR TITLE
Fix channel model select semantics+simplifications

### DIFF
--- a/model/channel/channel.go
+++ b/model/channel/channel.go
@@ -6,40 +6,35 @@ import (
 	"github.com/goose-lang/primitive"
 )
 
-type ChannelState uint64
+type OfferState uint64
 
 const (
-	// Only start and closed used for buffered channels.
-	start          ChannelState = 0
-	receiver_ready ChannelState = 1
-	sender_ready   ChannelState = 2
-	receiver_done  ChannelState = 3
-	sender_done    ChannelState = 4
-	closed         ChannelState = 5
+	// Only idle and closed used for buffered channels.
+	idle OfferState = 0
+	// v = nil means receiver is making offer, v non-nil means sender is making offer
+	offer    OfferState = 1
+	accepted OfferState = 2
+	closed   OfferState = 3
 )
 
 type Channel[T any] struct {
 	lock  *sync.Mutex
-	state ChannelState
+	state OfferState
 
-	// Values only used for buffered channels. The length of buffer being 0 is how we determine a
-	// channel is unbuffered. buffer is a circular queue that represents the channel's buffer
 	buffer []T
-	first  uint64
-	count  uint64
+	cap    uint64
 
 	// Value only used for unbuffered channels
-	v T
+	v *T
 }
 
 // buffer_size = 0 is an unbuffered channel
 func NewChannelRef[T any](buffer_size uint64) *Channel[T] {
 	return &Channel[T]{
-		buffer: make([]T, buffer_size),
+		buffer: make([]T, 0),
 		lock:   new(sync.Mutex),
-		first:  0,
-		count:  0,
-		state:  start,
+		cap:    buffer_size,
+		state:  idle,
 	}
 }
 
@@ -90,15 +85,18 @@ func (c *Channel[T]) Receive() (T, bool) {
 // may be successful exchanges that need to complete, which is equivalent to the go runtime where
 // the closer must still obtain the channel's lock
 func (c *Channel[T]) TryClose() bool {
+	c.lock.Lock()
 	if c.state == closed {
 		panic("close of closed channel")
 	}
 	// For unbuffered channels, if there is an exchange in progress, let the exchange complete.
-	// In the real channel code the lock is held while this happens.
-	if c.state != receiver_done && c.state != sender_done {
+	// In the runtime channel code the lock is held while this happens.
+	if c.state == idle {
 		c.state = closed
+		c.lock.Unlock()
 		return true
 	}
+	c.lock.Unlock()
 	return false
 }
 
@@ -113,9 +111,7 @@ func (c *Channel[T]) Close() {
 	}
 	var done bool = false
 	for !done {
-		c.lock.Lock()
 		done = c.TryClose()
-		c.lock.Unlock()
 	}
 }
 
@@ -132,57 +128,42 @@ func (c *Channel[T]) ReceiveDiscardOk() T {
 }
 
 // If there is a value available in the buffer, consume it, otherwise, don't select.
-func (c *Channel[T]) BufferedTryReceiveLocked() (bool, T, bool) {
+func (c *Channel[T]) BufferedTryReceive() (bool, T, bool) {
+	c.lock.Lock()
 	var v T
-	if c.count > 0 {
-		c.v = c.buffer[c.first]
-		c.first = (c.first + 1) % uint64(len(c.buffer))
-		c.count -= 1
-		return true, c.v, true
+	if len(c.buffer) > 0 {
+		val_copy := c.buffer[0]
+		c.buffer = c.buffer[1:]
+		c.lock.Unlock()
+		return true, val_copy, true
 	}
 	if c.state == closed {
+		c.lock.Unlock()
 		return true, v, false
 	}
+	c.lock.Unlock()
 	return false, v, true
 }
 
-func (c *Channel[T]) BufferedTryReceive() (bool, T, bool) {
-	c.lock.Lock()
-	selected, return_val, ok := c.BufferedTryReceiveLocked()
-	c.lock.Unlock()
-	return selected, return_val, ok
-}
-
-type OfferResult uint64
-
-const (
-	OfferRescinded        OfferResult = 0 // Offer was rescinded (other party didn't arrive in time)
-	CompletedExchange     OfferResult = 1 // Other party responded to our offer
-	CloseInterruptedOffer OfferResult = 2 // Unexpected state, indicates model bugs.
-)
-
-func (c *Channel[T]) UnbufferedTryReceive() (bool, T, bool) {
+func (c *Channel[T]) UnbufferedTryReceive(blocking bool) (bool, T, bool) {
 	var local_val T
 	// First critical section: determine state and get value if sender is ready
 	c.lock.Lock()
-	// No exchange in progress, make an offer, which will "lock" the channel from other
-	// receivers since they will do nothing in this function if receiver_ready is observed.
 	if c.state == closed {
 		c.lock.Unlock()
 		return true, local_val, false
 	}
-	if c.state == sender_ready {
-		local_val = c.v
-		c.state = receiver_done
+	// Sender is making an offer, complete it
+	if c.state == offer && c.v != nil {
+		local_val = *c.v
+		c.state = accepted
 		c.lock.Unlock()
 		return true, local_val, true
 	}
-	if c.state == sender_done || c.state == receiver_ready || c.state == receiver_done {
-		c.lock.Unlock()
-		return false, local_val, true
-	}
-	if c.state == start {
-		c.state = receiver_ready
+
+	// Channel idle, we can make an offer
+	if c.state == idle && blocking {
+		c.state = offer
 		c.lock.Unlock()
 		c.lock.Lock()
 		if c.state == closed {
@@ -190,15 +171,16 @@ func (c *Channel[T]) UnbufferedTryReceive() (bool, T, bool) {
 			return true, local_val, false
 		}
 		// Offer wasn't accepted in time, rescind it.
-		if c.state == receiver_ready {
-			c.state = start
+		if c.state == offer {
+			c.state = idle
 			c.lock.Unlock()
 			return false, local_val, true
 		}
 		// Offer was accepted, complete the exchange.
-		if c.state == sender_done {
-			c.state = start
-			local_val = c.v
+		if c.state == accepted {
+			c.state = idle
+			local_val = *c.v
+			c.v = nil
 			c.lock.Unlock()
 			return true, local_val, true
 		}
@@ -206,111 +188,101 @@ func (c *Channel[T]) UnbufferedTryReceive() (bool, T, bool) {
 		// for us but other receivers cannot.
 		panic("not supposed to be here!")
 	}
+	// If another exchange is in progress we'll try again unless we are nonblocking.
+	if c.state == accepted || c.state == offer || !blocking {
+		c.lock.Unlock()
+		return false, local_val, true
+	}
 	// We should be exhaustively handling these cases but Go wants a return everywhere
 	panic("not supposed to be here!")
 }
 
 // Non-blocking receive function used for select statements. Blocking receive is modeled as
 // a single blocking select statement which amounts to a for loop until selected.
-func (c *Channel[T]) TryReceive() (bool, T, bool) {
-	if uint64(len(c.buffer)) > 0 {
+// The blocking parameter here is used to determine whether or not we will make an offer to a
+// waiting sender. If true, we will make an offer since blocking receive is modeled as a for loop
+// around nonblocking TryReceive. If false, we don't make an offer since we don't need to match
+// with another non-blocking send.
+func (c *Channel[T]) TryReceive(blocking bool) (bool, T, bool) {
+	if c.cap > 0 {
 		return c.BufferedTryReceive()
 	} else {
-		return c.UnbufferedTryReceive()
+		return c.UnbufferedTryReceive(blocking)
 	}
 }
 
-type SenderState uint64
-
-const (
-	SenderCompletedWithReceiver SenderState = 0 // Sender found a waiting receiver
-	SenderMadeOffer             SenderState = 1 // Sender made an offer (no receiver waiting)
-	SenderCannotProceed         SenderState = 2 // Exchange in progress, don't select
-)
-
-func (c *Channel[T]) SenderCompleteOrOffer(val T) SenderState {
+func (c *Channel[T]) UnbufferedTrySend(val T, blocking bool) bool {
+	c.lock.Lock()
 	if c.state == closed {
 		panic("send on closed channel")
 	}
 	// Receiver waiting, complete exchange.
-	if c.state == receiver_ready {
-		c.state = sender_done
-		c.v = val
-		return SenderCompletedWithReceiver
+	if c.state == offer && c.v == nil {
+		c.v = new(T)
+		c.state = accepted
+		*c.v = val
+		c.lock.Unlock()
+		return true
 	}
 	// No exchange in progress, make an offer.
-	if c.state == start {
-		c.state = sender_ready
+	// Make an offer only if blocking.
+	if c.state == idle && blocking {
+		c.v = new(T)
+		c.state = offer
 		// Save the value in case the receiver completes the exchange.
-		c.v = val
-		return SenderMadeOffer
+		*c.v = val
+		c.lock.Unlock()
+		c.lock.Lock()
+		// Receiver accepts, reset the channel.
+		if c.state == accepted {
+			c.state = idle
+			c.v = nil
+			c.lock.Unlock()
+			return true
+		}
+		// Offer still stands, rescind it.
+		if c.state == offer {
+			c.state = idle
+			c.v = nil
+			c.lock.Unlock()
+			return false
+		}
+		// This protocol doesn't work if other parties can cancel the exchange.
+		panic("Invalid state transition with open receive offer")
 	}
-	// Exchange in progress, don't select.
-	return SenderCannotProceed
-}
-
-func (c *Channel[T]) SenderCheckOfferResult() OfferResult {
-	if c.state == closed {
-		panic("send on closed channel")
-	}
-	// Receiver accepted offer, complete exchange.
-	if c.state == receiver_done {
-		c.state = start
-		return CompletedExchange
-	}
-	// Offer still stands, rescind it.
-	if c.state == sender_ready {
-		c.state = start
-		return OfferRescinded
-	}
-	panic("Invalid state transition with open receive offer")
+	c.lock.Unlock()
+	return false
 }
 
 // If the buffer has free space, push our value.
 func (c *Channel[T]) BufferedTrySend(val T) bool {
+	c.lock.Lock()
 	if c.state == closed {
 		panic("send on closed channel")
 	}
 
 	// If we have room, buffer our value
-	if c.count < uint64(len(c.buffer)) {
-		var last uint64 = (c.first + c.count) % uint64(len(c.buffer))
-		c.buffer[last] = val
-		c.count += 1
+	if len(c.buffer) < int(c.cap) {
+		c.buffer = append(c.buffer, val)
+		c.lock.Unlock()
 		return true
 	}
+	c.lock.Unlock()
 	return false
 }
 
 // Non-Blocking send operation for select statements. Blocking send and blocking select
 // statements simply call this in a for loop until it returns true.
-func (c *Channel[T]) TrySend(val T) bool {
-	var buffer_size uint64 = uint64(len(c.buffer))
+func (c *Channel[T]) TrySend(val T, blocking bool) bool {
 
+	sendResult := false
 	// Buffered channel:
-	if buffer_size != 0 {
-		c.lock.Lock()
-		sendResult := c.BufferedTrySend(val)
-		c.lock.Unlock()
-		return sendResult
+	if c.cap != 0 {
+		sendResult = c.BufferedTrySend(val)
+	} else {
+		sendResult = c.UnbufferedTrySend(val, blocking)
 	}
-
-	// Unbuffered channel:
-	// First critical section: Try to complete send or make offer
-	c.lock.Lock()
-	senderState := c.SenderCompleteOrOffer(val)
-	c.lock.Unlock()
-
-	// Second critical section: Handle offer case if needed
-	if senderState == SenderMadeOffer {
-		c.lock.Lock()
-		offerResult := c.SenderCheckOfferResult()
-		c.lock.Unlock()
-		return offerResult == CompletedExchange
-	}
-
-	// If we didn't make an offer, we either selected or an exchange is in progress so we bail.
-	return senderState == SenderCompletedWithReceiver
+	return sendResult
 }
 
 // c.Len()
@@ -326,7 +298,7 @@ func (c *Channel[T]) Len() uint64 {
 	}
 	var chan_len uint64 = 0
 	c.lock.Lock()
-	chan_len = c.count
+	chan_len = uint64(len(c.buffer))
 	c.lock.Unlock()
 	return chan_len
 }
@@ -339,7 +311,7 @@ func (c *Channel[T]) Cap() uint64 {
 	if c == nil {
 		return 0
 	}
-	return uint64(len(c.buffer))
+	return c.cap
 }
 
 // The code below models select statements in a similar way to the reflect package's
@@ -378,19 +350,19 @@ func NewRecvCase[T any](channel *Channel[T]) *SelectCase[T] {
 
 // Uses the applicable Try<Operation> function on the select case's channel. Default is always
 // selectable so simply returns true.
-func TrySelect[T any](select_case *SelectCase[T]) bool {
+func TrySelect[T any](select_case *SelectCase[T], blocking bool) bool {
 	var channel *Channel[T] = select_case.channel
 	if channel == nil {
 		return false
 	}
 	if select_case.dir == SelectSend {
-		return channel.TrySend(select_case.Value)
+		return channel.TrySend(select_case.Value, blocking)
 	}
 	if select_case.dir == SelectRecv {
 		var item T
 		var ok bool
 		var selected bool
-		selected, item, ok = channel.TryReceive()
+		selected, item, ok = channel.TryReceive(blocking)
 		// We can use these values for return by reference and they will be implicitly kept alive
 		// by the garbage collector so we can use value here for both the send and receive
 		// variants. What a miracle it is to not be using C++.
@@ -410,7 +382,7 @@ func Select1[T1 any](
 	blocking bool) bool {
 	var selected bool
 	for {
-		selected = TrySelect(case1)
+		selected = TrySelect(case1, blocking)
 		if selected || !blocking {
 			break
 		}
@@ -421,12 +393,12 @@ func Select1[T1 any](
 func TrySelectCase2[T1, T2 any](
 	index uint64,
 	case1 *SelectCase[T1],
-	case2 *SelectCase[T2]) bool {
+	case2 *SelectCase[T2], blocking bool) bool {
 	if index == 0 {
-		return TrySelect(case1)
+		return TrySelect(case1, blocking)
 	}
 	if index == 1 {
-		return TrySelect(case2)
+		return TrySelect(case2, blocking)
 	}
 	panic("index needs to be 0 or 1")
 }
@@ -437,16 +409,16 @@ func Select2[T1, T2 any](
 	blocking bool) uint64 {
 
 	i := primitive.RandomUint64() % uint64(2)
-	if TrySelectCase2(i, case1, case2) {
+	if TrySelectCase2(i, case1, case2, blocking) {
 		return i
 	}
 
 	// If nothing was selected and we're blocking, try in a loop
 	for {
-		if TrySelect(case1) {
+		if TrySelect(case1, blocking) {
 			return 0
 		}
-		if TrySelect(case2) {
+		if TrySelect(case2, blocking) {
 			return 1
 		}
 		if !blocking {
@@ -459,15 +431,15 @@ func TrySelectCase3[T1, T2, T3 any](
 	index uint64,
 	case1 *SelectCase[T1],
 	case2 *SelectCase[T2],
-	case3 *SelectCase[T3]) bool {
+	case3 *SelectCase[T3], blocking bool) bool {
 	if index == 0 {
-		return TrySelect(case1)
+		return TrySelect(case1, blocking)
 	}
 	if index == 1 {
-		return TrySelect(case2)
+		return TrySelect(case2, blocking)
 	}
 	if index == 2 {
-		return TrySelect(case3)
+		return TrySelect(case3, blocking)
 	}
 	panic("index needs to be 0, 1 or 2")
 }
@@ -479,18 +451,18 @@ func Select3[T1, T2, T3 any](
 	blocking bool) uint64 {
 
 	i := primitive.RandomUint64() % uint64(3)
-	if TrySelectCase3(i, case1, case2, case3) {
+	if TrySelectCase3(i, case1, case2, case3, blocking) {
 		return i
 	}
 
 	for {
-		if TrySelect(case1) {
+		if TrySelect(case1, blocking) {
 			return 0
 		}
-		if TrySelect(case2) {
+		if TrySelect(case2, blocking) {
 			return 1
 		}
-		if TrySelect(case3) {
+		if TrySelect(case3, blocking) {
 			return 2
 		}
 		if !blocking {
@@ -504,18 +476,18 @@ func TrySelectCase4[T1, T2, T3, T4 any](
 	case1 *SelectCase[T1],
 	case2 *SelectCase[T2],
 	case3 *SelectCase[T3],
-	case4 *SelectCase[T4]) bool {
+	case4 *SelectCase[T4], blocking bool) bool {
 	if index == 0 {
-		return TrySelect(case1)
+		return TrySelect(case1, blocking)
 	}
 	if index == 1 {
-		return TrySelect(case2)
+		return TrySelect(case2, blocking)
 	}
 	if index == 2 {
-		return TrySelect(case3)
+		return TrySelect(case3, blocking)
 	}
 	if index == 3 {
-		return TrySelect(case4)
+		return TrySelect(case4, blocking)
 	}
 	panic("index needs to be 0, 1, 2 or 3")
 }
@@ -528,21 +500,21 @@ func Select4[T1, T2, T3, T4 any](
 	blocking bool) uint64 {
 
 	i := primitive.RandomUint64() % uint64(4)
-	if TrySelectCase4(i, case1, case2, case3, case4) {
+	if TrySelectCase4(i, case1, case2, case3, case4, blocking) {
 		return i
 	}
 
 	for {
-		if TrySelect(case1) {
+		if TrySelect(case1, blocking) {
 			return 0
 		}
-		if TrySelect(case2) {
+		if TrySelect(case2, blocking) {
 			return 1
 		}
-		if TrySelect(case3) {
+		if TrySelect(case3, blocking) {
 			return 2
 		}
-		if TrySelect(case4) {
+		if TrySelect(case4, blocking) {
 			return 3
 		}
 		if !blocking {
@@ -557,21 +529,21 @@ func TrySelectCase5[T1, T2, T3, T4, T5 any](
 	case2 *SelectCase[T2],
 	case3 *SelectCase[T3],
 	case4 *SelectCase[T4],
-	case5 *SelectCase[T5]) bool {
+	case5 *SelectCase[T5], blocking bool) bool {
 	if index == 0 {
-		return TrySelect(case1)
+		return TrySelect(case1, blocking)
 	}
 	if index == 1 {
-		return TrySelect(case2)
+		return TrySelect(case2, blocking)
 	}
 	if index == 2 {
-		return TrySelect(case3)
+		return TrySelect(case3, blocking)
 	}
 	if index == 3 {
-		return TrySelect(case4)
+		return TrySelect(case4, blocking)
 	}
 	if index == 4 {
-		return TrySelect(case5)
+		return TrySelect(case5, blocking)
 	}
 	panic("index needs to be 0, 1, 2, 3 or 4")
 }
@@ -585,24 +557,24 @@ func Select5[T1, T2, T3, T4, T5 any](
 	blocking bool) uint64 {
 
 	i := primitive.RandomUint64() % uint64(5)
-	if TrySelectCase5(i, case1, case2, case3, case4, case5) {
+	if TrySelectCase5(i, case1, case2, case3, case4, case5, blocking) {
 		return i
 	}
 
 	for {
-		if TrySelect(case1) {
+		if TrySelect(case1, blocking) {
 			return 0
 		}
-		if TrySelect(case2) {
+		if TrySelect(case2, blocking) {
 			return 1
 		}
-		if TrySelect(case3) {
+		if TrySelect(case3, blocking) {
 			return 2
 		}
-		if TrySelect(case4) {
+		if TrySelect(case4, blocking) {
 			return 3
 		}
-		if TrySelect(case5) {
+		if TrySelect(case5, blocking) {
 			return 4
 		}
 		if !blocking {

--- a/model/channel/channel_test.go
+++ b/model/channel/channel_test.go
@@ -45,12 +45,12 @@ func TestChan(t *testing.T) {
 			}
 			// Ensure that non-blocking receive does not block.
 
-			selected, _, _ := c.TryReceive()
+			selected, _, _ := c.TryReceive(false)
 			if selected {
 				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
 			}
 
-			selected, _, _ = c.TryReceive()
+			selected, _, _ = c.TryReceive(false)
 			if selected {
 				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
 			}
@@ -73,7 +73,7 @@ func TestChan(t *testing.T) {
 			if atomic.LoadUint32(&sent) != 0 {
 				t.Fatalf("chan[%d]: send to full chan", chanCap)
 			}
-			selected := c.TrySend(0)
+			selected := c.TrySend(0, false)
 			if selected {
 				t.Fatalf("chan[%d]: send to full chan", chanCap)
 			}
@@ -536,7 +536,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		ourChan := channel.NewChannelRef[int](1)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
-			ourChan.TrySend(42)
+			ourChan.TrySend(42, false)
 		})
 
 		// Compare results
@@ -572,7 +572,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		ourChan := channel.NewChannelRef[int](5)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
-			ourChan.TrySend(42)
+			ourChan.TrySend(42, false)
 		})
 
 		// Compare results
@@ -629,7 +629,7 @@ func TestNonblockRecvRace(t *testing.T) {
 		c := channel.NewChannelRef[uint64](1)
 		c.Send(1)
 		go func() {
-			selected, _, _ := c.TryReceive()
+			selected, _, _ := c.TryReceive(false)
 			if !selected {
 				t.Error("chan is not ready")
 			}
@@ -656,7 +656,7 @@ func TestMultiConsumer(t *testing.T) {
 		wg.Add(1)
 		go func(w uint64) {
 			for {
-				selected, val, ok := q.TryReceive()
+				selected, val, ok := q.TryReceive(false)
 				if !ok {
 					break
 				}
@@ -688,7 +688,7 @@ func TestMultiConsumer(t *testing.T) {
 	var n uint64 = 0
 	var s uint64 = 0
 	for {
-		selected, val, ok := r.TryReceive()
+		selected, val, ok := r.TryReceive(false)
 		if !ok {
 			break
 		}
@@ -818,7 +818,7 @@ func TestNonblockSelectRace(t *testing.T) {
 			done.Send(true)
 		}()
 		c2.Send(1)
-		c1.TryReceive()
+		c1.TryReceive(false)
 		val := done.ReceiveDiscardOk()
 		if !val {
 			t.Fatal("no chan is ready")
@@ -850,7 +850,7 @@ func TestNonblockSelectRace2(t *testing.T) {
 			done.Send(true)
 		}()
 		c2.Close()
-		c1.TryReceive()
+		c1.TryReceive(false)
 		val := done.ReceiveDiscardOk()
 		if !val {
 			t.Fatal("no chan is ready")
@@ -1317,5 +1317,48 @@ func TestSelect5(t *testing.T) {
 	}
 	if emptyCase4.Value != 0 {
 		t.Errorf("expected emptyCase4.Value=0 (zero value) for closed channel, got %v", emptyCase4.Value)
+	}
+}
+
+// Two non blocking selects should not match up.
+func Test2NBSelectNoProgress(t *testing.T) {
+	c1 := channel.NewChannelRef[uint64](uint64(0))
+	case_1 := channel.NewRecvCase(c1)
+	case_2 := channel.NewSendCase(c1, 0)
+
+	// Run the receiver loop in a goroutine
+	doneRecv := make(chan struct{})
+	go func() {
+		for {
+			selected := channel.Select1(case_1, false)
+			if selected {
+				break
+			}
+		}
+		close(doneRecv)
+	}()
+
+	// Run the sender loop in this goroutine
+	doneSend := make(chan struct{})
+	go func() {
+		for {
+			selected := channel.Select1(case_2, false)
+			if selected {
+				break
+			}
+		}
+		close(doneSend)
+	}()
+
+	// Use a timeout: test passes if both loops never make progress
+	timeout := time.After(2 * time.Second)
+
+	select {
+	case <-doneRecv:
+		t.Fatal("unexpected progress in recv loop: expected to block")
+	case <-doneSend:
+		t.Fatal("unexpected progress in send loop: expected to block")
+	case <-timeout:
+		// Good: timeout reached, nothing made progress
 	}
 }


### PR DESCRIPTION
This is a somewhat minor refactor to the channel model in a new folder that will be used for the new logically atomic specs. 

Reduced state complexity: Changed from 6 states (start, receiver_ready, sender_ready, receiver_done, sender_done, closed) to 4 states (idle, offer, accepted, closed)

Unified offer state: Use the value pointer to distinguish offer types instead of separate states:
offer + v == nil means receiver is waiting
offer + v != nil means sender is waiting

Fixed non-blocking select semantics: Added Test2NBSelectNoProgress which was failing in the old model. Non-blocking operations were incorrectly able to match with each other by making offers. Now non-blocking operations only attempt immediate completion.
Added blocking parameter: TryReceive and TrySend now take a blocking parameter to control whether they make offers or only try immediate completion.

Companion Perennial PR is https://github.com/mit-pdos/perennial/pull/330
