### PR TITLE
Better support generics with known underlying type

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -891,18 +891,20 @@ func (ctx *Ctx) selectorExpr(e *ast.SelectorExpr) glang.Expr {
 }
 
 func (ctx *Ctx) compositeLiteral(e *ast.CompositeLit) glang.Expr {
-	if t, ok := ctx.typeOf(e).Underlying().(*types.Slice); ok {
+	eT := underlyingType(ctx.typeOf(e))
+	switch t := eT.(type) {
+	case *types.Slice:
 		return ctx.sliceLiteral(e.Elts, t.Elem())
-	} else if t, ok := ctx.typeOf(e).Underlying().(*types.Array); ok {
+	case *types.Array:
 		return ctx.arrayLiteral(e, t.Elem())
-	} else if t, ok := ctx.typeOf(e).Underlying().(*types.Map); ok {
+	case *types.Map:
 		return ctx.mapLiteral(e, t.Key(), t.Elem())
+	case *types.Struct:
+		return ctx.structLiteral(ctx.typeOf(e), t, e)
+	default:
+		ctx.unsupported(e, "composite literal of type %v (%T)", eT, eT)
+		return nil
 	}
-	if structType, ok := ctx.typeOf(e).Underlying().(*types.Struct); ok {
-		return ctx.structLiteral(ctx.typeOf(e), structType, e)
-	}
-	ctx.unsupported(e, "composite literal of type %v", ctx.typeOf(e))
-	return nil
 }
 
 func isUnkeyedStruct(e *ast.CompositeLit) bool {
@@ -1277,6 +1279,49 @@ func (ctx *Ctx) goBuiltin(e *ast.Ident) bool {
 	return s.Parent() == types.Universe
 }
 
+// if types.Type is an interface that holds a single type, get that type; these
+// typically show up as constraints in generic functions, e.g. `T ~[]int`
+func getInterfaceSingletonType(t types.Type) (types.Type, bool) {
+	if t, ok := t.Underlying().(*types.Interface); ok {
+		if t.NumEmbeddeds() == 1 {
+			t := t.EmbeddedType(0)
+			if t, ok := t.(*types.Union); ok {
+				if t.Len() == 1 {
+					// singleton union (possibly with term.Tilde() being true)
+					term := t.Term(0)
+					// the single type in the union is unionT
+					unionT := term.Type()
+					return unionT, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
+// underlyingType returns the underlying type of t, including if t is of an
+// singleton interface.
+func underlyingType(t types.Type) types.Type {
+	if t, ok := getInterfaceSingletonType(t); ok {
+		return t.Underlying()
+	}
+	return t.Underlying()
+}
+
+func getSliceType(t types.Type) (*types.Slice, bool) {
+	if t, ok := underlyingType(t).(*types.Slice); ok {
+		return t, true
+	}
+	return nil, false
+}
+
+func getMapType(t types.Type) (*types.Map, bool) {
+	if t, ok := underlyingType(t).(*types.Map); ok {
+		return t, true
+	}
+	return nil, false
+}
+
 func (ctx *Ctx) builtinIdent(e *ast.Ident) glang.Expr {
 	switch e.Name {
 	case "nil":
@@ -1288,12 +1333,12 @@ func (ctx *Ctx) builtinIdent(e *ast.Ident) glang.Expr {
 	case "append":
 		sig := ctx.typeOf(e).(*types.Signature)
 		t := sig.Params().At(0).Type()
-		if t, ok := t.Underlying().(*types.Slice); ok {
+		if t, ok := getSliceType(t); ok {
 			return glang.NewCallExpr(glang.GallinaVerbatim("slice.append"),
 				glang.GolangTypeExpr(ctx.glangType(e, t.Elem())),
 			)
 		}
-		ctx.unsupported(e, "append to %v with unknown element type", t)
+		ctx.unsupported(e, "append to %v (%T) with unknown element type", t, t.Underlying())
 	case "new":
 		sig := ctx.typeOf(e).(*types.Signature)
 		ctx.todo(e, "new might be better as its own function")
@@ -1303,7 +1348,8 @@ func (ctx *Ctx) builtinIdent(e *ast.Ident) glang.Expr {
 		}
 	case "len":
 		sig := ctx.typeOf(e).(*types.Signature)
-		switch ty := sig.Params().At(0).Type().Underlying().(type) {
+		argT := underlyingType(sig.Params().At(0).Type())
+		switch ty := argT.(type) {
 		case *types.Slice:
 			return glang.GallinaVerbatim("slice.len")
 		case *types.Map:
@@ -1315,11 +1361,12 @@ func (ctx *Ctx) builtinIdent(e *ast.Ident) glang.Expr {
 		case *types.Chan:
 			return glang.GallinaVerbatim("chan.len")
 		default:
-			ctx.unsupported(e, "length of object of type %v", ty)
+			ctx.unsupported(e, "length of object of type %v (%T)", ty, ty)
 		}
 	case "cap":
 		sig := ctx.typeOf(e).(*types.Signature)
-		switch ty := sig.Params().At(0).Type().Underlying().(type) {
+		argT := underlyingType(sig.Params().At(0).Type())
+		switch ty := argT.(type) {
 		case *types.Slice:
 			return glang.GallinaVerbatim("slice.cap")
 		case *types.Chan:
@@ -1329,8 +1376,8 @@ func (ctx *Ctx) builtinIdent(e *ast.Ident) glang.Expr {
 		}
 	case "copy":
 		sig := ctx.typeOf(e).(*types.Signature)
-		switch ty := sig.Params().At(0).Type().Underlying().(type) {
-		case *types.Slice:
+		argT := sig.Params().At(0).Type().Underlying()
+		if ty, ok := getSliceType(argT); ok {
 			fromTy := sig.Params().At(1).Type().Underlying()
 			if types.Identical(ty, fromTy) {
 				return glang.NewCallExpr(
@@ -1338,13 +1385,13 @@ func (ctx *Ctx) builtinIdent(e *ast.Ident) glang.Expr {
 					glang.GolangTypeExpr(ctx.glangType(e, ty.Elem())),
 				)
 			}
-			ctx.unsupported(e, "copy to %v from %v", ty, fromTy)
-		default:
-			ctx.nope(e, "copy of object of type %v", ty)
+			ctx.unsupported(e, "slice copy to %v from %v", ty, fromTy)
 		}
+		// the destination of a copy should always be a slice
+		ctx.nope(e, "copy of object of type %v", argT)
 	case "delete":
 		sig := ctx.typeOf(e).(*types.Signature)
-		if _, ok := sig.Params().At(0).Type().Underlying().(*types.Map); !ok {
+		if _, ok := getMapType(sig.Params().At(0).Type().Underlying()); !ok {
 			ctx.nope(e, "delete on non-map")
 		}
 		return glang.GallinaVerbatim("map.delete")
@@ -1961,8 +2008,8 @@ func (ctx *Ctx) handleImplicitConversion(n locatable, from, to types.Type, e gla
 	}
 	from = types.Unalias(from)
 	to = types.Unalias(to)
-	fromUnder := from.Underlying()
-	toUnder := to.Underlying()
+	fromUnder := underlyingType(from)
+	toUnder := underlyingType(to)
 	if types.Identical(fromUnder, toUnder) {
 		return e
 	}

--- a/testdata/examples/unittest/generics/constraints.go
+++ b/testdata/examples/unittest/generics/constraints.go
@@ -1,0 +1,12 @@
+package generics
+
+func UnderlyingSlice[T ~[]int](s T) int {
+	return len(s)
+}
+
+// Clone copies a generic slice.
+//
+// Slightly simplified from [slices.Clone].
+func Clone[S ~[]E, E any](s S) S {
+	return append(S{}, s...)
+}

--- a/testdata/examples/unittest/generics/generics.gold.v
+++ b/testdata/examples/unittest/generics/generics.gold.v
@@ -16,6 +16,29 @@ Section code.
 Context `{ffi_syntax}.
 
 
+Definition UnderlyingSlice : go_string := "github.com/goose-lang/goose/testdata/examples/unittest/generics.UnderlyingSlice"%go.
+
+(* go: constraints.go:3:6 *)
+Definition UnderlyingSliceⁱᵐᵖˡ : val :=
+  λ: "T" "s",
+    exception_do (let: "s" := (mem.alloc "s") in
+    return: (let: "$a0" := (!["T"] "s") in
+     slice.len "$a0")).
+
+Definition Clone : go_string := "github.com/goose-lang/goose/testdata/examples/unittest/generics.Clone"%go.
+
+(* Clone copies a generic slice.
+
+   Slightly simplified from [slices.Clone].
+
+   go: constraints.go:10:6 *)
+Definition Cloneⁱᵐᵖˡ : val :=
+  λ: "S" "E" "s",
+    exception_do (let: "s" := (mem.alloc "s") in
+    return: (let: "$a0" := #slice.nil in
+     let: "$a1" := (!["S"] "s") in
+     (slice.append "E") "$a0" "$a1")).
+
 Definition Box : val :=
   λ: "T", type.structT [
     (#"Value"%go, "T")
@@ -196,7 +219,7 @@ Definition useAnyPointerⁱᵐᵖˡ : val :=
 
 Definition vars' : list (go_string * go_type) := [].
 
-Definition functions' : list (go_string * val) := [(BoxGet, BoxGetⁱᵐᵖˡ); (BoxGet2, BoxGet2ⁱᵐᵖˡ); (makeGenericBox, makeGenericBoxⁱᵐᵖˡ); (makeBox, makeBoxⁱᵐᵖˡ); (useBoxGet, useBoxGetⁱᵐᵖˡ); (useContainer, useContainerⁱᵐᵖˡ); (useMultiParam, useMultiParamⁱᵐᵖˡ); (swapMultiParam, swapMultiParamⁱᵐᵖˡ); (multiParamFunc, multiParamFuncⁱᵐᵖˡ); (useMultiParamFunc, useMultiParamFuncⁱᵐᵖˡ); (useAnyPointer, useAnyPointerⁱᵐᵖˡ)].
+Definition functions' : list (go_string * val) := [(UnderlyingSlice, UnderlyingSliceⁱᵐᵖˡ); (Clone, Cloneⁱᵐᵖˡ); (BoxGet, BoxGetⁱᵐᵖˡ); (BoxGet2, BoxGet2ⁱᵐᵖˡ); (makeGenericBox, makeGenericBoxⁱᵐᵖˡ); (makeBox, makeBoxⁱᵐᵖˡ); (useBoxGet, useBoxGetⁱᵐᵖˡ); (useContainer, useContainerⁱᵐᵖˡ); (useMultiParam, useMultiParamⁱᵐᵖˡ); (swapMultiParam, swapMultiParamⁱᵐᵖˡ); (multiParamFunc, multiParamFuncⁱᵐᵖˡ); (useMultiParamFunc, useMultiParamFuncⁱᵐᵖˡ); (useAnyPointer, useAnyPointerⁱᵐᵖˡ)].
 
 Definition msets' : list (go_string * (list (go_string * val))) := [(Box.id, [("Get"%go, Box__Getⁱᵐᵖˡ)]); (ptrT.id Box.id, [("Get"%go, (λ: "$recvAddr",
                  method_call #generics.generics #"Box" #"Get" (![Box #()] "$recvAddr")


### PR DESCRIPTION
If a generic function has an input `T ~[]E` and then an input `v T`, slice operations should be available on `v`, and if the element type is needed, it is known to be `E`. This commit improves that support, including some (but probably not all) cases of the same issue for maps and channels.

The upshot of this is that we can now translate [slices.Clone](https://cs.opensource.google/go/go/+/refs/tags/go1.25.0:src/slices/slices.go;l=353).

Fixes #117.