### PR TITLE
Make go_types opaque by default

### DIFF
--- a/glang/types.go
+++ b/glang/types.go
@@ -134,6 +134,11 @@ func (d TypeDecl) CoqDecl() string {
 	pp.Add("Definition %s : val :=", GallinaIdent(d.Name).Coq(false))
 	pp.Indent(2)
 	pp.Add("λ: %s, %s.", typeBinders(d.TypeParams), d.Body.Coq(false))
+	// XXX: Opaque does not imply Typeclasses Opaque.
+	// https://rocq-prover.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Opaque.20does.20not.20imply.20Typeclasses.20Opaque
+	// https://github.com/rocq-prover/rocq/issues/19482
+	pp.Add("#[global] Typeclasses Opaque %s.", GallinaIdent(d.Name).Coq(false))
+	pp.Add("#[global] Opaque %s.", GallinaIdent(d.Name).Coq(false))
 	return pp.Build()
 }
 
@@ -157,6 +162,8 @@ func (gd GallinaTypeDecl) CoqDecl() string {
 	}
 
 	pp.Add("Definition %s %s: go_type := %s.", GallinaIdent(d.Name).Coq(false), typeParams, d.Body.Gallina(false))
+	pp.Add("#[global] Typeclasses Opaque %s.", GallinaIdent(d.Name).Coq(false))
+	pp.Add("#[global] Opaque %s.", GallinaIdent(d.Name).Coq(false))
 	return pp.Build()
 }
 

--- a/proofgen/tmpl/type_simple.tmpl
+++ b/proofgen/tmpl/type_simple.tmpl
@@ -1,10 +1,10 @@
 Module {{.Name}}.
-{{- /* simple types do not need to be kept Opaque; the unfolded type in this
+{{/* simple types do not need to be kept Opaque; the unfolded type in this
     case is a valid go_type to search for a Gallina representation for. With
     structs, the problem is that each new struct has its own record, so if e.g. two
     structs happen to have the same fields of the same types, there will be two
     different `Type`s for a single `go_type` which causes typeclass search to
-    sometimes pick the wrong onel. in a proof */ -}}
+    sometimes pick the wrong onel. in a proof */}}
 #[global] Transparent {{.PkgName}}.{{.Name}}.
 #[global] Typeclasses Transparent {{.PkgName}}.{{.Name}}.
 Section def.

--- a/proofgen/tmpl/type_simple.tmpl
+++ b/proofgen/tmpl/type_simple.tmpl
@@ -1,4 +1,12 @@
 Module {{.Name}}.
+{{- /* simple types do not need to be kept Opaque; the unfolded type in this
+    case is a valid go_type to search for a Gallina representation for. With
+    structs, the problem is that each new struct has its own record, so if e.g. two
+    structs happen to have the same fields of the same types, there will be two
+    different `Type`s for a single `go_type` which causes typeclass search to
+    sometimes pick the wrong onel. in a proof */ -}}
+#[global] Transparent {{.PkgName}}.{{.Name}}.
+#[global] Typeclasses Transparent {{.PkgName}}.{{.Name}}.
 Section def.
 Context `{ffi_syntax}.
 Definition t := {{.TypeInfo.Body}}.

--- a/proofgen/tmpl/type_struct.tmpl
+++ b/proofgen/tmpl/type_struct.tmpl
@@ -44,12 +44,12 @@ Section instances.
 Context `{ffi_syntax}.
 {{ if $TypeParams -}}
 Context {{- template "_typeparams.tmpl" $TypeParams -}}.
+{{ end -}}
 
 Global Instance {{$name}}_ty_wf : struct.Wf {{$T.GoTypeName}}.
 Proof. apply _. Qed.
-{{ end -}}
 
-{{ if $Fields }}
+{{ if $Fields -}}
 Global Instance settable_{{$name}} : Settable {{$T.GallinaType}} :=
   settable! {{if $TypeParams -}}
 ({{$name}}.mk {{- range $T_param := $TypeParams -}}

--- a/proofgen/tmpl/type_struct.tmpl
+++ b/proofgen/tmpl/type_struct.tmpl
@@ -54,6 +54,7 @@ Global Instance settable_{{$name}} : Settable {{$T.GallinaType}} :=
 {{- end }} >.
 {{ end -}}
 
+#[local] Transparent {{$T.PkgName}}.{{$name}}.
 Global Instance into_val_{{$name}} : IntoVal {{$T.GallinaType}} :=
   {| to_val_def v :=
     struct.val_aux {{$T.GoTypeName}} [

--- a/proofgen/tmpl/type_struct.tmpl
+++ b/proofgen/tmpl/type_struct.tmpl
@@ -46,7 +46,10 @@ Context `{ffi_syntax}.
 Context {{- template "_typeparams.tmpl" $TypeParams -}}.
 {{ end -}}
 
-Global Instance {{$name}}_ty_wf : struct.Wf {{$T.GoTypeName}}.
+#[local] Transparent {{$T.PkgName}}.{{$name}}.
+#[local] Typeclasses Transparent {{$T.PkgName}}.{{$name}}.
+
+Global Instance {{$name}}_wf : struct.Wf {{$T.GoTypeName}}.
 Proof. apply _. Qed.
 
 {{ if $Fields -}}
@@ -61,8 +64,6 @@ Global Instance settable_{{$name}} : Settable {{$T.GallinaType}} :=
 {{- end }} >.
 {{ end -}}
 
-#[local] Transparent {{$T.PkgName}}.{{$name}}.
-#[local] Typeclasses Transparent {{$T.PkgName}}.{{$name}}.
 Global Instance into_val_{{$name}} : IntoVal {{$T.GallinaType}} :=
   {| to_val_def v :=
     struct.val_aux {{$T.GoTypeName}} [

--- a/proofgen/tmpl/type_struct.tmpl
+++ b/proofgen/tmpl/type_struct.tmpl
@@ -14,7 +14,10 @@ Definition ty {{ if $TypeParams -}}
   {{indent 2}}"{{$f.Name}}" :: {{$f.GoType}}{{.Sep}}
 {{ end -}}
 ]%struct.
+#[global] Typeclasses Opaque ty.
+#[global] Opaque ty.
 {{ end -}}
+
 Record t {{ template "_typeparams.tmpl" $TypeParams -}}
 := mk {
 {{ range $Fields -}}
@@ -23,6 +26,10 @@ Record t {{ template "_typeparams.tmpl" $TypeParams -}}
 }.
 End def.
 End {{$name}}.
+
+{{ if .TypeInfo.IsGooseLang -}}
+#[local] Transparent {{.Name}}.ty.
+{{ end -}}
 
 {{ if $TypeParams -}}
 Arguments {{$name}}.mk {_} {{ range $T_param := $TypeParams -}}
@@ -55,6 +62,7 @@ Global Instance settable_{{$name}} : Settable {{$T.GallinaType}} :=
 {{ end -}}
 
 #[local] Transparent {{$T.PkgName}}.{{$name}}.
+#[local] Typeclasses Transparent {{$T.PkgName}}.{{$name}}.
 Global Instance into_val_{{$name}} : IntoVal {{$T.GallinaType}} :=
   {| to_val_def v :=
     struct.val_aux {{$T.GoTypeName}} [

--- a/testdata/examples/append_log/append_log.gold.v
+++ b/testdata/examples/append_log/append_log.gold.v
@@ -19,6 +19,8 @@ Definition Log : go_type := structT [
   "sz" :: uint64T;
   "diskSz" :: uint64T
 ].
+#[global] Typeclasses Opaque Log.
+#[global] Opaque Log.
 
 (* go: append_log.go:22:17 *)
 Definition Log__mkHdrⁱᵐᵖˡ : val :=

--- a/testdata/examples/comments/comments.gold.v
+++ b/testdata/examples/comments/comments.gold.v
@@ -18,6 +18,8 @@ Definition TWO : val := #(W64 2).
 Definition Foo : go_type := structT [
   "a" :: boolT
 ].
+#[global] Typeclasses Opaque Foo.
+#[global] Opaque Foo.
 
 Definition vars' : list (go_string * go_type) := [].
 

--- a/testdata/examples/interfacerecursion/interfacerecursion.gold.v
+++ b/testdata/examples/interfacerecursion/interfacerecursion.gold.v
@@ -14,11 +14,17 @@ Context `{ffi_syntax}.
 
 
 Definition A : go_type := interfaceT.
+#[global] Typeclasses Opaque A.
+#[global] Opaque A.
 
 Definition B : go_type := interfaceT.
+#[global] Typeclasses Opaque B.
+#[global] Opaque B.
 
 Definition c : go_type := structT [
 ].
+#[global] Typeclasses Opaque c.
+#[global] Opaque c.
 
 (* go: x.go:14:13 *)
 Definition c__Fooⁱᵐᵖˡ : val :=

--- a/testdata/examples/logging2/logging2.gold.v
+++ b/testdata/examples/logging2/logging2.gold.v
@@ -32,6 +32,8 @@ Definition Log : go_type := structT [
   "memTxnNxt" :: ptrT;
   "logTxnNxt" :: ptrT
 ].
+#[global] Typeclasses Opaque Log.
+#[global] Opaque Log.
 
 (* go: logging2.go:25:16 *)
 Definition Log__writeHdrⁱᵐᵖˡ : val :=
@@ -290,6 +292,8 @@ Definition Txn : go_type := structT [
   "log" :: ptrT;
   "blks" :: mapT uint64T sliceT
 ].
+#[global] Typeclasses Opaque Txn.
+#[global] Opaque Txn.
 
 Definition Begin : go_string := "github.com/goose-lang/goose/testdata/examples/logging2.Begin"%go.
 

--- a/testdata/examples/semantics/semantics.gold.v
+++ b/testdata/examples/semantics/semantics.gold.v
@@ -37,6 +37,8 @@ Section code.
 
 Definition unit : go_type := structT [
 ].
+#[global] Typeclasses Opaque unit.
+#[global] Opaque unit.
 
 Definition findKey : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.findKey"%go.
 
@@ -196,8 +198,12 @@ Definition testMaxUint64ⁱᵐᵖˡ : val :=
      (maxUint64 2) "$a0" "$a1") = #(W64 10))).
 
 Definition AdderType : go_type := funcT.
+#[global] Typeclasses Opaque AdderType.
+#[global] Opaque AdderType.
 
 Definition MultipleArgsType : go_type := funcT.
+#[global] Typeclasses Opaque MultipleArgsType.
+#[global] Opaque MultipleArgsType.
 
 Definition adder : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.adder"%go.
 
@@ -523,6 +529,8 @@ Definition testDeferFuncLitⁱᵐᵖˡ : val :=
 Definition Enc : go_type := structT [
   "p" :: sliceT
 ].
+#[global] Typeclasses Opaque Enc.
+#[global] Opaque Enc.
 
 (* go: encoding.go:10:15 *)
 Definition Enc__consumeⁱᵐᵖˡ : val :=
@@ -541,6 +549,8 @@ Definition Enc__consumeⁱᵐᵖˡ : val :=
 Definition Dec : go_type := structT [
   "p" :: sliceT
 ].
+#[global] Typeclasses Opaque Dec.
+#[global] Opaque Dec.
 
 (* go: encoding.go:20:15 *)
 Definition Dec__consumeⁱᵐᵖˡ : val :=
@@ -747,6 +757,8 @@ Definition Editor : go_type := structT [
   "s" :: sliceT;
   "next_val" :: uint64T
 ].
+#[global] Typeclasses Opaque Editor.
+#[global] Opaque Editor.
 
 (* advances the array editor, and returns the value it wrote, storing
    "next" in next_val
@@ -786,6 +798,8 @@ Definition Pair : go_type := structT [
   "x" :: uint64T;
   "y" :: uint64T
 ].
+#[global] Typeclasses Opaque Pair.
+#[global] Opaque Pair.
 
 Definition failing_testFunctionOrdering : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.failing_testFunctionOrdering"%go.
 
@@ -940,6 +954,8 @@ Definition testU32Lenⁱᵐᵖˡ : val :=
      slice.len "$a0")) = #(W32 100))).
 
 Definition Uint32 : go_type := uint32T.
+#[global] Typeclasses Opaque Uint32.
+#[global] Opaque Uint32.
 
 Definition failing_testU32NewtypeLen : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.failing_testU32NewtypeLen"%go.
 
@@ -955,6 +971,8 @@ Definition failing_testU32NewtypeLenⁱᵐᵖˡ : val :=
      slice.len "$a0")) = #(W32 20))).
 
 Definition geometryInterface : go_type := interfaceT.
+#[global] Typeclasses Opaque geometryInterface.
+#[global] Opaque geometryInterface.
 
 Definition measureArea : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.measureArea"%go.
 
@@ -985,6 +1003,8 @@ Definition measureVolumeⁱᵐᵖˡ : val :=
 Definition SquareStruct : go_type := structT [
   "Side" :: uint64T
 ].
+#[global] Typeclasses Opaque SquareStruct.
+#[global] Opaque SquareStruct.
 
 (* go: interfaces.go:28:23 *)
 Definition SquareStruct__Squareⁱᵐᵖˡ : val :=
@@ -1144,6 +1164,8 @@ Definition standardForLoopⁱᵐᵖˡ : val :=
 Definition LoopStruct : go_type := structT [
   "loopNext" :: ptrT
 ].
+#[global] Typeclasses Opaque LoopStruct.
+#[global] Opaque LoopStruct.
 
 (* go: loops.go:28:22 *)
 Definition LoopStruct__forLoopWaitⁱᵐᵖˡ : val :=
@@ -2003,6 +2025,8 @@ Definition BoolTest : go_type := structT [
   "tc" :: uint64T;
   "fc" :: uint64T
 ].
+#[global] Typeclasses Opaque BoolTest.
+#[global] Opaque BoolTest.
 
 Definition CheckTrue : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.CheckTrue"%go.
 
@@ -2124,6 +2148,8 @@ Definition ArrayEditor : go_type := structT [
   "s" :: sliceT;
   "next_val" :: uint64T
 ].
+#[global] Typeclasses Opaque ArrayEditor.
+#[global] Opaque ArrayEditor.
 
 (* go: slices.go:9:24 *)
 Definition ArrayEditor__Advanceⁱᵐᵖˡ : val :=
@@ -2350,10 +2376,14 @@ Definition Bar : go_type := structT [
   "a" :: uint64T;
   "b" :: uint64T
 ].
+#[global] Typeclasses Opaque Bar.
+#[global] Opaque Bar.
 
 Definition Foo : go_type := structT [
   "bar" :: Bar
 ].
+#[global] Typeclasses Opaque Foo.
+#[global] Opaque Foo.
 
 (* go: struct_pointers.go:14:17 *)
 Definition Bar__mutateⁱᵐᵖˡ : val :=
@@ -2395,12 +2425,16 @@ Definition TwoInts : go_type := structT [
   "x" :: uint64T;
   "y" :: uint64T
 ].
+#[global] Typeclasses Opaque TwoInts.
+#[global] Opaque TwoInts.
 
 Definition S : go_type := structT [
   "a" :: uint64T;
   "b" :: TwoInts;
   "c" :: boolT
 ].
+#[global] Typeclasses Opaque S.
+#[global] Opaque S.
 
 Definition NewS : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.NewS"%go.
 
@@ -2611,6 +2645,8 @@ Definition testIncompleteStructⁱᵐᵖˡ : val :=
 Definition StructWrap : go_type := structT [
   "i" :: uint64T
 ].
+#[global] Typeclasses Opaque StructWrap.
+#[global] Opaque StructWrap.
 
 Definition testStoreInStructVar : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.testStoreInStructVar"%go.
 
@@ -2675,6 +2711,8 @@ Definition testStoreSliceⁱᵐᵖˡ : val :=
 Definition StructWithFunc : go_type := structT [
   "fn" :: funcT
 ].
+#[global] Typeclasses Opaque StructWithFunc.
+#[global] Opaque StructWithFunc.
 
 Definition testStructFieldFunc : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.testStructFieldFunc"%go.
 
@@ -2743,8 +2781,12 @@ Definition testSwitchDefaultTrueⁱᵐᵖˡ : val :=
 
 Definition switchConcrete : go_type := structT [
 ].
+#[global] Typeclasses Opaque switchConcrete.
+#[global] Opaque switchConcrete.
 
 Definition switchInterface : go_type := interfaceT.
+#[global] Typeclasses Opaque switchInterface.
+#[global] Opaque switchInterface.
 
 (* go: switch.go:45:26 *)
 Definition switchConcrete__markerⁱᵐᵖˡ : val :=
@@ -2819,6 +2861,8 @@ Definition Log : go_type := structT [
   "cache" :: mapT uint64T sliceT;
   "length" :: ptrT
 ].
+#[global] Typeclasses Opaque Log.
+#[global] Opaque Log.
 
 Definition intToBlock : go_string := "github.com/goose-lang/goose/testdata/examples/semantics.intToBlock"%go.
 

--- a/testdata/examples/simpledb/simpledb.gold.v
+++ b/testdata/examples/simpledb/simpledb.gold.v
@@ -33,6 +33,8 @@ Definition Table : go_type := structT [
   "Index" :: mapT uint64T uint64T;
   "File" :: fileT
 ].
+#[global] Typeclasses Opaque Table.
+#[global] Opaque Table.
 
 Definition CreateTable : go_string := "github.com/goose-lang/goose/testdata/examples/simpledb.CreateTable"%go.
 
@@ -71,6 +73,8 @@ Definition Entry : go_type := structT [
   "Key" :: uint64T;
   "Value" :: sliceT
 ].
+#[global] Typeclasses Opaque Entry.
+#[global] Opaque Entry.
 
 Definition DecodeUInt64 : go_string := "github.com/goose-lang/goose/testdata/examples/simpledb.DecodeUInt64"%go.
 
@@ -163,6 +167,8 @@ Definition lazyFileBuf : go_type := structT [
   "offset" :: uint64T;
   "next" :: sliceT
 ].
+#[global] Typeclasses Opaque lazyFileBuf.
+#[global] Opaque lazyFileBuf.
 
 Definition readTableIndex : go_string := "github.com/goose-lang/goose/testdata/examples/simpledb.readTableIndex"%go.
 
@@ -339,6 +345,8 @@ Definition bufFile : go_type := structT [
   "file" :: fileT;
   "buf" :: ptrT
 ].
+#[global] Typeclasses Opaque bufFile.
+#[global] Opaque bufFile.
 
 Definition newBuf : go_string := "github.com/goose-lang/goose/testdata/examples/simpledb.newBuf"%go.
 
@@ -413,6 +421,8 @@ Definition tableWriter : go_type := structT [
   "file" :: bufFile;
   "offset" :: ptrT
 ].
+#[global] Typeclasses Opaque tableWriter.
+#[global] Opaque tableWriter.
 
 Definition newTableWriter : go_string := "github.com/goose-lang/goose/testdata/examples/simpledb.newTableWriter"%go.
 
@@ -572,6 +582,8 @@ Definition Database : go_type := structT [
   "tableL" :: ptrT;
   "compactionL" :: ptrT
 ].
+#[global] Typeclasses Opaque Database.
+#[global] Opaque Database.
 
 Definition makeValueBuffer : go_string := "github.com/goose-lang/goose/testdata/examples/simpledb.makeValueBuffer"%go.
 

--- a/testdata/examples/unittest/generics/generics.gold.v
+++ b/testdata/examples/unittest/generics/generics.gold.v
@@ -43,6 +43,8 @@ Definition Box : val :=
   λ: "T", type.structT [
     (#"Value"%go, "T")
   ].
+  #[global] Typeclasses Opaque Box.
+  #[global] Opaque Box.
 
 Definition BoxGet : go_string := "github.com/goose-lang/goose/testdata/examples/unittest/generics.BoxGet"%go.
 
@@ -107,6 +109,8 @@ Definition Container : val :=
     (#"Z"%go, #ptrT);
     (#"W"%go, #uint64T)
   ].
+  #[global] Typeclasses Opaque Container.
+  #[global] Opaque Container.
 
 Definition useContainer : go_string := "github.com/goose-lang/goose/testdata/examples/unittest/generics.useContainer"%go.
 
@@ -141,18 +145,24 @@ Definition UseContainer : val :=
   λ: <>, type.structT [
     (#"X"%go, Container #uint64T)
   ].
+  #[global] Typeclasses Opaque UseContainer.
+  #[global] Opaque UseContainer.
 
 Definition OnlyIndirect : val :=
   λ: "T", type.structT [
     (#"X"%go, #sliceT);
     (#"Y"%go, #ptrT)
   ].
+  #[global] Typeclasses Opaque OnlyIndirect.
+  #[global] Opaque OnlyIndirect.
 
 Definition MultiParam : val :=
   λ: "A" "B", type.structT [
     (#"Y"%go, "B");
     (#"X"%go, "A")
   ].
+  #[global] Typeclasses Opaque MultiParam.
+  #[global] Opaque MultiParam.
 
 Definition useMultiParam : go_string := "github.com/goose-lang/goose/testdata/examples/unittest/generics.useMultiParam"%go.
 

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -62,6 +62,8 @@ Section code.
 
 
 Definition Foo : go_type := arrayT (W64 10) uint64T.
+#[global] Typeclasses Opaque Foo.
+#[global] Opaque Foo.
 
 Definition takesArray : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.takesArray"%go.
 
@@ -309,6 +311,8 @@ Definition chanRangeⁱᵐᵖˡ : val :=
 
 Definition importantStruct : go_type := structT [
 ].
+#[global] Typeclasses Opaque importantStruct.
+#[global] Opaque importantStruct.
 
 Definition doSubtleThings : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.doSubtleThings"%go.
 
@@ -527,6 +531,8 @@ Definition ifStmtInitializationⁱᵐᵖˡ : val :=
     else return: ((![#uint64T] "y") - #(W64 1))))).
 
 Definition stringWrapper : go_type := stringT.
+#[global] Typeclasses Opaque stringWrapper.
+#[global] Opaque stringWrapper.
 
 Definition typedLiteral : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.typedLiteral"%go.
 
@@ -593,6 +599,8 @@ Definition stringWrapperToStringⁱᵐᵖˡ : val :=
     return: (![#stringWrapper] "s")).
 
 Definition Uint32 : go_type := uint32T.
+#[global] Typeclasses Opaque Uint32.
+#[global] Opaque Uint32.
 
 Definition testU32NewtypeLen : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.testU32NewtypeLen"%go.
 
@@ -802,6 +810,8 @@ Definition getRandomⁱᵐᵖˡ : val :=
 Definition diskWrapper : go_type := structT [
   "d" :: disk.Disk
 ].
+#[global] Typeclasses Opaque diskWrapper.
+#[global] Opaque diskWrapper.
 
 Definition diskArgument : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.diskArgument"%go.
 
@@ -821,18 +831,26 @@ Definition diskArgumentⁱᵐᵖˡ : val :=
 Definition embedA : go_type := structT [
   "a" :: uint64T
 ].
+#[global] Typeclasses Opaque embedA.
+#[global] Opaque embedA.
 
 Definition embedB : go_type := structT [
   "embedA" :: embedA
 ].
+#[global] Typeclasses Opaque embedB.
+#[global] Opaque embedB.
 
 Definition embedC : go_type := structT [
   "embedB" :: ptrT
 ].
+#[global] Typeclasses Opaque embedC.
+#[global] Opaque embedC.
 
 Definition embedD : go_type := structT [
   "embedC" :: embedC
 ].
+#[global] Typeclasses Opaque embedD.
+#[global] Opaque embedD.
 
 (* go: embedded.go:19:17 *)
 Definition embedA__Fooⁱᵐᵖˡ : val :=
@@ -959,6 +977,8 @@ Definition anonymousParamⁱᵐᵖˡ : val :=
 Definition Enc : go_type := structT [
   "p" :: sliceT
 ].
+#[global] Typeclasses Opaque Enc.
+#[global] Opaque Enc.
 
 (* go: encoding.go:9:15 *)
 Definition Enc__consumeⁱᵐᵖˡ : val :=
@@ -999,6 +1019,8 @@ Definition Enc__UInt32ⁱᵐᵖˡ : val :=
 Definition Dec : go_type := structT [
   "p" :: sliceT
 ].
+#[global] Typeclasses Opaque Dec.
+#[global] Opaque Dec.
 
 (* go: encoding.go:27:15 *)
 Definition Dec__consumeⁱᵐᵖˡ : val :=
@@ -1031,6 +1053,8 @@ Definition Dec__UInt32ⁱᵐᵖˡ : val :=
      (func_call #primitive.UInt32Get) "$a0")).
 
 Definition Enum1 : go_type := uint64T.
+#[global] Typeclasses Opaque Enum1.
+#[global] Opaque Enum1.
 
 Definition Enum1A : val := #(W64 0).
 
@@ -1039,6 +1063,8 @@ Definition Enum1B : val := #(W64 1).
 Definition Enum1C : val := #(W64 2).
 
 Definition Enum2 : go_type := intT.
+#[global] Typeclasses Opaque Enum2.
+#[global] Opaque Enum2.
 
 (* line comment 1 *)
 Definition Enum2A : val := #(W64 1).
@@ -1153,14 +1179,20 @@ Definition FuncVarⁱᵐᵖˡ : val :=
     return: #()).
 
 Definition Fooer : go_type := interfaceT.
+#[global] Typeclasses Opaque Fooer.
+#[global] Opaque Fooer.
 
 Definition concreteFooer : go_type := structT [
   "a" :: uint64T
 ].
+#[global] Typeclasses Opaque concreteFooer.
+#[global] Opaque concreteFooer.
 
 Definition FooerUser : go_type := structT [
   "f" :: Fooer
 ].
+#[global] Typeclasses Opaque FooerUser.
+#[global] Opaque FooerUser.
 
 (* go: interfaces.go:15:25 *)
 Definition concreteFooer__Fooⁱᵐᵖˡ : val :=
@@ -1365,9 +1397,13 @@ Definition testConversionInMultiplePassThroughⁱᵐᵖˡ : val :=
     return: #()).
 
 Definition PointerInterface : go_type := interfaceT.
+#[global] Typeclasses Opaque PointerInterface.
+#[global] Opaque PointerInterface.
 
 Definition concrete1 : go_type := structT [
 ].
+#[global] Typeclasses Opaque concrete1.
+#[global] Opaque concrete1.
 
 (* go: interfaces.go:106:20 *)
 Definition concrete1__Fooⁱᵐᵖˡ : val :=
@@ -1427,8 +1463,12 @@ Definition signedMidpointⁱᵐᵖˡ : val :=
     return: (((![#intT] "x") + (![#intT] "y")) `quots` #(W64 2))).
 
 Definition my_u32 : go_type := uint32T.
+#[global] Typeclasses Opaque my_u32.
+#[global] Opaque my_u32.
 
 Definition also_u32 : go_type := my_u32.
+#[global] Typeclasses Opaque also_u32.
+#[global] Opaque also_u32.
 
 Definition ConstWithAbbrevType : val := #(W32 3).
 
@@ -1437,6 +1477,8 @@ Definition allTheLiterals : go_type := structT [
   "s" :: stringT;
   "b" :: boolT
 ].
+#[global] Typeclasses Opaque allTheLiterals.
+#[global] Opaque allTheLiterals.
 
 Definition normalLiterals : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.normalLiterals"%go.
 
@@ -1538,6 +1580,8 @@ Definition useCondVarⁱᵐᵖˡ : val :=
 Definition hasCondVar : go_type := structT [
   "cond" :: ptrT
 ].
+#[global] Typeclasses Opaque hasCondVar.
+#[global] Opaque hasCondVar.
 
 Definition ToBeDebugged : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.ToBeDebugged"%go.
 
@@ -1828,8 +1872,12 @@ Definition MapSizeⁱᵐᵖˡ : val :=
      map.len "$a0"))).
 
 Definition IntWrapper : go_type := uint64T.
+#[global] Typeclasses Opaque IntWrapper.
+#[global] Opaque IntWrapper.
 
 Definition MapWrapper : go_type := mapT uint64T boolT.
+#[global] Typeclasses Opaque MapWrapper.
+#[global] Opaque MapWrapper.
 
 Definition MapTypeAliases : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.MapTypeAliases"%go.
 
@@ -1854,6 +1902,8 @@ Definition mapElem : go_type := structT [
   "a" :: uint64T;
   "b" :: uint64T
 ].
+#[global] Typeclasses Opaque mapElem.
+#[global] Opaque mapElem.
 
 Definition mapUpdateField : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.mapUpdateField"%go.
 
@@ -2003,6 +2053,8 @@ Definition ComparePointerToNilⁱᵐᵖˡ : val :=
 Definition containsPointer : go_type := structT [
   "s" :: ptrT
 ].
+#[global] Typeclasses Opaque containsPointer.
+#[global] Opaque containsPointer.
 
 Definition useNilField : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.useNilField"%go.
 
@@ -2100,6 +2152,8 @@ Definition Negativeⁱᵐᵖˡ : val :=
 Definition wrapExternalStruct : go_type := structT [
   "j" :: ptrT
 ].
+#[global] Typeclasses Opaque wrapExternalStruct.
+#[global] Opaque wrapExternalStruct.
 
 (* go: package.go:13:29 *)
 Definition wrapExternalStruct__joinⁱᵐᵖˡ : val :=
@@ -2132,11 +2186,15 @@ Definition Oracleⁱᵐᵖˡ : val :=
 Definition typing : go_type := structT [
   "proph" :: ptrT
 ].
+#[global] Typeclasses Opaque typing.
+#[global] Opaque typing.
 
 Definition composite : go_type := structT [
   "a" :: uint64T;
   "b" :: uint64T
 ].
+#[global] Typeclasses Opaque composite.
+#[global] Opaque composite.
 
 Definition ReassignVars : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.ReassignVars"%go.
 
@@ -2178,6 +2236,8 @@ Definition recurⁱᵐᵖˡ : val :=
 
 Definition R : go_type := structT [
 ].
+#[global] Typeclasses Opaque R.
+#[global] Opaque R.
 
 (* go: recursive.go:10:13 *)
 Definition R__recurMethodⁱᵐᵖˡ : val :=
@@ -2189,10 +2249,14 @@ Definition R__recurMethodⁱᵐᵖˡ : val :=
 Definition Other : go_type := structT [
   "RecursiveEmbedded" :: ptrT
 ].
+#[global] Typeclasses Opaque Other.
+#[global] Opaque Other.
 
 Definition RecursiveEmbedded : go_type := structT [
   "Other" :: Other
 ].
+#[global] Typeclasses Opaque RecursiveEmbedded.
+#[global] Opaque RecursiveEmbedded.
 
 (* go: recursive.go:22:29 *)
 Definition RecursiveEmbedded__recurEmbeddedMethodⁱᵐᵖˡ : val :=
@@ -2214,6 +2278,8 @@ Definition useRenamedImportⁱᵐᵖˡ : val :=
 Definition Block : go_type := structT [
   "Value" :: uint64T
 ].
+#[global] Typeclasses Opaque Block.
+#[global] Opaque Block.
 
 Definition Disk1 : val := #(W64 0).
 
@@ -2435,6 +2501,8 @@ Definition VoidImplicitReturnInBranchⁱᵐᵖˡ : val :=
     return: #()).
 
 Definition SliceAlias : go_type := sliceT.
+#[global] Typeclasses Opaque SliceAlias.
+#[global] Opaque SliceAlias.
 
 Definition sliceOps : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.sliceOps"%go.
 
@@ -2474,10 +2542,14 @@ Definition makeSingletonSliceⁱᵐᵖˡ : val :=
 Definition thing : go_type := structT [
   "x" :: uint64T
 ].
+#[global] Typeclasses Opaque thing.
+#[global] Opaque thing.
 
 Definition sliceOfThings : go_type := structT [
   "things" :: sliceT
 ].
+#[global] Typeclasses Opaque sliceOfThings.
+#[global] Opaque sliceOfThings.
 
 (* go: slices.go:26:25 *)
 Definition sliceOfThings__getThingRefⁱᵐᵖˡ : val :=
@@ -2596,6 +2668,8 @@ Definition Point : go_type := structT [
   "x" :: uint64T;
   "y" :: uint64T
 ].
+#[global] Typeclasses Opaque Point.
+#[global] Opaque Point.
 
 (* go: struct_method.go:8:16 *)
 Definition Point__Addⁱᵐᵖˡ : val :=
@@ -2660,12 +2734,16 @@ Definition TwoInts : go_type := structT [
   "x" :: uint64T;
   "y" :: uint64T
 ].
+#[global] Typeclasses Opaque TwoInts.
+#[global] Opaque TwoInts.
 
 Definition S : go_type := structT [
   "a" :: uint64T;
   "b" :: TwoInts;
   "c" :: boolT
 ].
+#[global] Typeclasses Opaque S.
+#[global] Opaque S.
 
 Definition NewS : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.NewS"%go.
 
@@ -2812,9 +2890,13 @@ Definition sleepⁱᵐᵖˡ : val :=
 Definition B : go_type := structT [
   "a" :: sliceT
 ].
+#[global] Typeclasses Opaque B.
+#[global] Opaque B.
 
 Definition A : go_type := structT [
 ].
+#[global] Typeclasses Opaque A.
+#[global] Opaque A.
 
 Definition mkInt : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.mkInt"%go.
 
@@ -2832,12 +2914,20 @@ Definition mkNothingⁱᵐᵖˡ : val :=
     return: #()).
 
 Definition my_u64 : go_type := uint64T.
+#[global] Typeclasses Opaque my_u64.
+#[global] Opaque my_u64.
 
 Definition Timestamp : go_type := uint64T.
+#[global] Typeclasses Opaque Timestamp.
+#[global] Opaque Timestamp.
 
 Definition UseTypeAbbrev : go_type := uint64T.
+#[global] Typeclasses Opaque UseTypeAbbrev.
+#[global] Opaque UseTypeAbbrev.
 
 Definition UseNamedType : go_type := Timestamp.
+#[global] Typeclasses Opaque UseNamedType.
+#[global] Opaque UseNamedType.
 
 Definition convertToAlias : go_string := "github.com/goose-lang/goose/testdata/examples/unittest.convertToAlias"%go.
 

--- a/testdata/examples/wal/wal.gold.v
+++ b/testdata/examples/wal/wal.gold.v
@@ -25,6 +25,8 @@ Definition Log : go_type := structT [
   "cache" :: mapT uint64T sliceT;
   "length" :: ptrT
 ].
+#[global] Typeclasses Opaque Log.
+#[global] Opaque Log.
 
 Definition intToBlock : go_string := "github.com/goose-lang/goose/testdata/examples/wal.intToBlock"%go.
 


### PR DESCRIPTION
This helps avoid problematic proof steps in which e.g. a `type foo struct{}` gets confused for another `type bar struct{}`, even though they have distinct Rocq record representations.