### PR TITLE
Add `Set` to `GallinaKeywords`

### DIFF
--- a/glang/coq.go
+++ b/glang/coq.go
@@ -114,6 +114,7 @@ type Expr interface {
 }
 
 var GallinaKeywords map[string]bool = map[string]bool{
+	"Set":    true,
 	"Type":   true,
 	"is":     true,
 	"as":     true,


### PR DESCRIPTION
This PR adds `Set` to `GallinaKeywords` to avoid conflicts when a `Set` type is defined, e.g., https://pkg.go.dev/k8s.io/apimachinery/pkg/labels#Set