### PR TITLE
Add a higher-order channel example

### DIFF
--- a/testdata/examples/channel/examples_test.go
+++ b/testdata/examples/channel/examples_test.go
@@ -1,6 +1,9 @@
 package chan_spec_raw_examples
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestAll(t *testing.T) {
 	TestHelloWorldSync()
@@ -9,4 +12,12 @@ func TestAll(t *testing.T) {
 	TestFibConsumer()
 	TestSelectNbNoPanic()
 	TestSelectReadyCaseNoPanic()
+}
+
+func TestHigherOrderExample(t *testing.T) {
+	responses := HigherOrderExample()
+	expected := []string{"hello world", "HELLO", "world"}
+	if !strings.EqualFold(strings.Join(responses, ""), strings.Join(expected, "")) {
+		t.Errorf("Expected %v, got %v", expected, responses)
+	}
 }

--- a/testdata/examples/channel/higher_order.go
+++ b/testdata/examples/channel/higher_order.go
@@ -1,0 +1,37 @@
+package chan_spec_raw_examples
+
+type request struct {
+	f      func() string
+	result chan string
+}
+
+func mkRequest(f func() string) request {
+	return request{f: f, result: make(chan string, 1)}
+}
+
+func ho_worker(c chan request) {
+	for r := range c {
+		r.result <- r.f()
+	}
+}
+
+func HigherOrderExample() []string {
+	c := make(chan request)
+	go ho_worker(c)
+	go ho_worker(c)
+
+	r1 := mkRequest(func() string { return "hello" + " world" })
+	r2 := mkRequest(func() string { return "HELLO" })
+	r3 := mkRequest(func() string { return "w" + "o" + "rld" })
+
+	c <- r1
+	c <- r2
+	c <- r3
+
+	responses := []string{
+		<-r1.result,
+		<-r2.result,
+		<-r3.result,
+	}
+	return responses
+}


### PR DESCRIPTION
Loosely based on Effective Go's channels of channels example, but also with a function passed in the request.