### PR TITLE
Make elimination stack modular and emulate time.after

### DIFF
--- a/testdata/examples/channel/elimination_stack.go
+++ b/testdata/examples/channel/elimination_stack.go
@@ -5,49 +5,84 @@ import (
 	"time"
 )
 
-type EliminationStack struct {
-	stack     []string
-	mu        sync.Mutex
-	exchanger chan string
+// LockedStack is a simple mutex-protected LIFO stack.
+type LockedStack struct {
+	mu    sync.Mutex
+	stack []string
 }
 
-func NewEliminationStack() *EliminationStack {
-	return &EliminationStack{
-		stack:     make([]string, 0),
-		exchanger: make(chan string),
-	}
+func NewLockedStack() *LockedStack {
+	return &LockedStack{stack: make([]string, 0)}
 }
 
-func (s *EliminationStack) Push(value string) {
-	// Try single-slot elimination once.
-	select {
-	case s.exchanger <- value:
-		return
-	case <-time.After(10 * time.Microsecond):
-		// fall through to central stack
-	}
-	// Central stack fallback
+func (s *LockedStack) Push(value string) {
 	s.mu.Lock()
 	s.stack = append(s.stack, value)
 	s.mu.Unlock()
 }
 
-func (s *EliminationStack) Pop() (string, bool) {
-	// Try single-slot elimination once.
-	select {
-	case v := <-s.exchanger:
-		return v, true // eliminated with a concurrent Push
-	case <-time.After(10 * time.Microsecond):
-		// fall through to central stack
-	}
-	// Central stack fallback
+func (s *LockedStack) Pop() (string, bool) {
 	s.mu.Lock()
 	if len(s.stack) == 0 {
 		s.mu.Unlock()
 		return "", false
 	}
-	v := s.stack[len(s.stack)-1]
-	s.stack = s.stack[:len(s.stack)-1]
+	last := len(s.stack) - 1
+	v := s.stack[last]
+	s.stack = s.stack[:last]
 	s.mu.Unlock()
 	return v, true
+}
+
+// after returns a channel that closes after d (emulates time.After).
+func after(d time.Duration) <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		time.Sleep(d)
+		close(ch)
+	}()
+	return ch
+}
+
+// EliminationStack composes a single-slot exchanger over a LockedStack.
+type EliminationStack struct {
+	base      *LockedStack
+	exchanger chan string // unbuffered: rendezvous
+	timeout   time.Duration
+}
+
+// NewEliminationStack constructs a new elimination stack
+// using a fresh LockedStack and a small default timeout.
+func NewEliminationStack() *EliminationStack {
+	return &EliminationStack{
+		base:      NewLockedStack(),
+		exchanger: make(chan string),
+		timeout:   10 * time.Microsecond,
+	}
+}
+
+// Push first tries one-shot elimination; on timeout, falls back to the locked stack.
+func (s *EliminationStack) Push(value string) {
+	t := after(s.timeout)
+	select {
+	case s.exchanger <- value:
+		// Eliminated with a concurrent Pop.
+		return
+	case <-t:
+		// Timeout; use central stack.
+	}
+	s.base.Push(value)
+}
+
+// Pop first tries one-shot elimination; on timeout, falls back to the locked stack.
+func (s *EliminationStack) Pop() (string, bool) {
+	t := after(s.timeout)
+	select {
+	case v := <-s.exchanger:
+		// Eliminated with a concurrent Push.
+		return v, true
+	case <-t:
+		// Timeout; use central stack.
+	}
+	return s.base.Pop()
 }

--- a/testdata/examples/channel/muxer.go
+++ b/testdata/examples/channel/muxer.go
@@ -33,17 +33,51 @@ func Muxer(c chan stream) {
 	}
 }
 
-// 4. CancellableMuxer - muxer with cancellation
-func CancellableMuxer(c chan stream, done chan struct{}) {
+func CancellableMapServer(s stream, done chan struct{}) {
 	for {
 		select {
-		case s, ok := <-c:
+		case in, ok := <-s.req:
 			if !ok {
 				return
 			}
-			go MapServer(s)
+			s.res <- s.f(in)
 		case <-done:
 			return
 		}
 	}
+}
+
+// 4. CancellableMuxer - muxer with cancellation
+func CancellableMuxer(c chan stream, done chan struct{}, errMsg *string) string {
+	for {
+		select {
+		case s, ok := <-c:
+			if !ok {
+				return "serviced all requests"
+			}
+			go CancellableMapServer(s, done)
+		case <-done:
+			return *errMsg
+		}
+	}
+}
+
+func makeGreeting() string {
+	// Start muxer
+	mux := make(chan stream, 2)
+	go Muxer(mux)
+
+	// Two simple streams
+	comma := mkStream(func(s string) string { return s + "," })
+	exclaim := mkStream(func(s string) string { return s + "!" })
+
+	// Submit to muxer
+	mux <- comma
+	mux <- exclaim
+
+	// Use them
+	comma.req <- "Hello"
+	exclaim.req <- "World"
+
+	return <-comma.res + " " + <-exclaim.res
 }

--- a/testdata/examples/channel/muxer_test.go
+++ b/testdata/examples/channel/muxer_test.go
@@ -130,7 +130,7 @@ func TestMuxerConcurrent(t *testing.T) {
 	close(streamChan)
 }
 
-func testCancellation(t *testing.T) {
+func TestCancellation(t *testing.T) {
 	mux := make(chan stream)
 	done := make(chan struct{})
 	errMsg := ""

--- a/testdata/examples/channel/muxer_test.go
+++ b/testdata/examples/channel/muxer_test.go
@@ -157,7 +157,7 @@ func TestCancellation(t *testing.T) {
 	fmt.Println("Muxer result:", <-result)
 }
 
-func testNormalShutdown(t *testing.T) {
+func TestNormalShutdown(t *testing.T) {
 	mux := make(chan stream)
 	done := make(chan struct{})
 	errMsg := ""

--- a/testdata/examples/channel/muxer_test.go
+++ b/testdata/examples/channel/muxer_test.go
@@ -86,49 +86,6 @@ func TestMuxer(t *testing.T) {
 	close(streamChan)
 }
 
-func TestCancellableMuxer(t *testing.T) {
-	streamChan := make(chan stream)
-	done := make(chan struct{})
-
-	go CancellableMuxer(streamChan, done)
-
-	s := mkStream(func(input string) string {
-		return "result-" + input
-	})
-
-	streamChan <- s
-
-	// Verify it works before cancellation
-	s.req <- "test"
-	select {
-	case result := <-s.res:
-		if result != "result-test" {
-			panic(fmt.Sprintf("Expected 'result-test', got '%s'", result))
-		}
-	case <-time.After(100 * time.Millisecond):
-		panic("CancellableMuxer timed out before cancellation")
-	}
-
-	// Cancel the muxer
-	close(done)
-	time.Sleep(10 * time.Millisecond) // Give it time to shutdown
-
-	// The muxer should have stopped, but existing streams should still work
-	// since MapServer is already running
-	s.req <- "test2"
-	select {
-	case result := <-s.res:
-		if result != "result-test2" {
-			panic(fmt.Sprintf("Expected 'result-test2', got '%s'", result))
-		}
-	case <-time.After(100 * time.Millisecond):
-		panic("Existing stream timed out after cancellation")
-	}
-
-	close(s.req)
-	close(streamChan)
-}
-
 func TestMuxerConcurrent(t *testing.T) {
 	streamChan := make(chan stream, 10)
 
@@ -171,4 +128,53 @@ func TestMuxerConcurrent(t *testing.T) {
 
 	wg.Wait()
 	close(streamChan)
+}
+
+func testCancellation(t *testing.T) {
+	mux := make(chan stream)
+	done := make(chan struct{})
+	errMsg := ""
+
+	result := make(chan string)
+	go func() {
+		result <- CancellableMuxer(mux, done, &errMsg)
+	}()
+
+	// Slow stream that takes 200ms
+	slow := mkStream(func(s string) string {
+		time.Sleep(200 * time.Millisecond)
+		return "processed: " + s
+	})
+
+	mux <- slow
+	slow.req <- "data"
+
+	// Set error BEFORE closing done
+	time.Sleep(50 * time.Millisecond)
+	errMsg = "timeout: operation took too long"
+	close(done)
+
+	fmt.Println("Muxer result:", <-result)
+}
+
+func testNormalShutdown(t *testing.T) {
+	mux := make(chan stream)
+	done := make(chan struct{})
+	errMsg := ""
+
+	result := make(chan string)
+	go func() {
+		result <- CancellableMuxer(mux, done, &errMsg)
+	}()
+
+	// Submit and process a stream
+	fast := mkStream(func(s string) string { return s + "!" })
+	mux <- fast
+	fast.req <- "done"
+	fmt.Println(<-fast.res)
+
+	// Close channel normally
+	close(mux)
+
+	fmt.Println("Muxer result:", <-result)
 }


### PR DESCRIPTION
This is to support first verifying the simpler locked stack and also I don't want to verify the real time.after but this should be fine 