### PR TITLE
More channel tests

### DIFF
--- a/model/channel/channel_spec_test.go
+++ b/model/channel/channel_spec_test.go
@@ -96,3 +96,5 @@ func TestSpecClose(t *testing.T) {
 		assert.Equal(0, v)
 	}
 }
+
+// TODO: test https://pkg.go.dev/reflect#Select

--- a/model/channel/channel_test.go
+++ b/model/channel/channel_test.go
@@ -1224,3 +1224,5 @@ func TestIter(t *testing.T) {
 	}
 	assert.Equalf(t, expected, actual, "wrong values")
 }
+
+// TODO: test https://pkg.go.dev/reflect#Select

--- a/model/go_channel/channel.go
+++ b/model/go_channel/channel.go
@@ -3,25 +3,21 @@
 // This is only used for testing the model - it makes it easy to use the same example with the model and Go channels.
 package go_channel
 
-type Channel[T any] struct {
-	ch chan T
-}
+type Channel[T any] chan T
 
-func NewChannel[T any](cap int) *Channel[T] {
-	return &Channel[T]{
-		ch: make(chan T, cap),
-	}
+func NewChannel[T any](cap int) Channel[T] {
+	return make(chan T, cap)
 }
 
 // Non-Blocking send operation for select statements. Blocking send and blocking select
 // statements simply call this in a for loop until it returns true.
-func (c *Channel[T]) TrySend(val T, blocking bool) bool {
+func (c Channel[T]) TrySend(val T, blocking bool) bool {
 	if blocking {
-		c.ch <- val
+		c <- val
 		return true
 	}
 	select {
-	case c.ch <- val:
+	case c <- val:
 		return true
 	default:
 		return false
@@ -33,12 +29,8 @@ func (c *Channel[T]) TrySend(val T, blocking bool) bool {
 // is equivalent to:
 //
 // c <- val
-func (c *Channel[T]) Send(v T) {
-	if c == nil {
-		for {
-		}
-	}
-	c.ch <- v
+func (c Channel[T]) Send(v T) {
+	c <- v
 }
 
 // Non-blocking receive function used for select statements.
@@ -46,13 +38,13 @@ func (c *Channel[T]) Send(v T) {
 // waiting sender. If true, we will make an offer since blocking receive is modeled as a for loop
 // around nonblocking TryReceive. If false, we don't make an offer since we don't need to match
 // with another non-blocking send.
-func (c *Channel[T]) TryReceive(blocking bool) (bool, T, bool) {
+func (c Channel[T]) TryReceive(blocking bool) (bool, T, bool) {
 	if blocking {
-		v, ok := <-c.ch
+		v, ok := <-c
 		return true, v, ok
 	}
 	select {
-	case v, ok := <-c.ch:
+	case v, ok := <-c:
 		return true, v, ok
 	default:
 		var zero T
@@ -66,13 +58,8 @@ func (c *Channel[T]) TryReceive(blocking bool) (bool, T, bool) {
 // channels. This should be able to be solved by adding an overload wrapper that discards the ok
 // bool.
 
-func (c *Channel[T]) Receive() (T, bool) {
-	if c == nil {
-		// Block forever
-		for {
-		}
-	}
-	v, ok := <-c.ch
+func (c Channel[T]) Receive() (T, bool) {
+	v, ok := <-c
 	return v, ok
 }
 
@@ -81,18 +68,15 @@ func (c *Channel[T]) Receive() (T, bool) {
 // is equivalent to:
 //
 // close(c)
-func (c *Channel[T]) Close() {
-	if c == nil {
-		panic("close of nil channel")
-	}
-	close(c.ch)
+func (c Channel[T]) Close() {
+	close(c)
 }
 
 // v := c.ReceiveDiscardOk
 //
 // is equivalent to:
 // v := c<-
-func (c *Channel[T]) ReceiveDiscardOk() T {
+func (c Channel[T]) ReceiveDiscardOk() T {
 	return_val, _ := c.Receive()
 	return return_val
 }
@@ -104,28 +88,22 @@ func (c *Channel[T]) ReceiveDiscardOk() T {
 //
 // This might not be worth specifying since it is hard to make good use of channel length
 // semantics.
-func (c *Channel[T]) Len() int {
-	if c == nil {
-		return 0
-	}
-	return len(c.ch)
+func (c Channel[T]) Len() int {
+	return len(c)
 }
 
 // c.Cap()
 //
 // is equivalent to:
 // cap(c)
-func (c *Channel[T]) Cap() int {
-	if c == nil {
-		return 0
-	}
-	return cap(c.ch)
+func (c Channel[T]) Cap() int {
+	return cap(c)
 }
 
 // c.Iter() returns an iterator that models a for range loop over the channel.
-func (c *Channel[T]) Iter() func(yield func(T) bool) {
+func (c Channel[T]) Iter() func(yield func(T) bool) {
 	return func(yield func(T) bool) {
-		for v := range c.ch {
+		for v := range c {
 			if !yield(v) {
 				return
 			}

--- a/model/go_channel/channel.go
+++ b/model/go_channel/channel.go
@@ -1,0 +1,4 @@
+// Package go_channel provides the same interface as model/channel, but using the built-in channels as the implementation.
+//
+// This is only used for testing the model - it makes it easy to use the same example with the model and Go channels.
+package go_channel

--- a/model/go_channel/channel.go
+++ b/model/go_channel/channel.go
@@ -2,3 +2,133 @@
 //
 // This is only used for testing the model - it makes it easy to use the same example with the model and Go channels.
 package go_channel
+
+type Channel[T any] struct {
+	ch chan T
+}
+
+func NewChannel[T any](cap int) *Channel[T] {
+	return &Channel[T]{
+		ch: make(chan T, cap),
+	}
+}
+
+// Non-Blocking send operation for select statements. Blocking send and blocking select
+// statements simply call this in a for loop until it returns true.
+func (c *Channel[T]) TrySend(val T, blocking bool) bool {
+	if blocking {
+		c.ch <- val
+		return true
+	}
+	select {
+	case c.ch <- val:
+		return true
+	default:
+		return false
+	}
+}
+
+// c.Send(val)
+//
+// is equivalent to:
+//
+// c <- val
+func (c *Channel[T]) Send(v T) {
+	if c == nil {
+		for {
+		}
+	}
+	c.ch <- v
+}
+
+// Non-blocking receive function used for select statements.
+// The blocking parameter here is used to determine whether or not we will make an offer to a
+// waiting sender. If true, we will make an offer since blocking receive is modeled as a for loop
+// around nonblocking TryReceive. If false, we don't make an offer since we don't need to match
+// with another non-blocking send.
+func (c *Channel[T]) TryReceive(blocking bool) (bool, T, bool) {
+	if blocking {
+		v, ok := <-c.ch
+		return true, v, ok
+	}
+	select {
+	case v, ok := <-c.ch:
+		return true, v, ok
+	default:
+		var zero T
+		return false, zero, true
+	}
+}
+
+// Equivalent to:
+// value, ok := <-c
+// Notably, this requires the user to consume the ok bool which is not actually required with Go
+// channels. This should be able to be solved by adding an overload wrapper that discards the ok
+// bool.
+
+func (c *Channel[T]) Receive() (T, bool) {
+	if c == nil {
+		// Block forever
+		for {
+		}
+	}
+	v, ok := <-c.ch
+	return v, ok
+}
+
+// c.Close()
+//
+// is equivalent to:
+//
+// close(c)
+func (c *Channel[T]) Close() {
+	if c == nil {
+		panic("close of nil channel")
+	}
+	close(c.ch)
+}
+
+// v := c.ReceiveDiscardOk
+//
+// is equivalent to:
+// v := c<-
+func (c *Channel[T]) ReceiveDiscardOk() T {
+	return_val, _ := c.Receive()
+	return return_val
+}
+
+// c.Len()
+//
+// is equivalent to:
+// len(c)
+//
+// This might not be worth specifying since it is hard to make good use of channel length
+// semantics.
+func (c *Channel[T]) Len() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.ch)
+}
+
+// c.Cap()
+//
+// is equivalent to:
+// cap(c)
+func (c *Channel[T]) Cap() int {
+	if c == nil {
+		return 0
+	}
+	return cap(c.ch)
+}
+
+// c.Iter() returns an iterator that models a for range loop over the channel.
+func (c *Channel[T]) Iter() func(yield func(T) bool) {
+	return func(yield func(T) bool) {
+		for v := range c.ch {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}

--- a/model/go_channel/channel_spec_test.go
+++ b/model/go_channel/channel_spec_test.go
@@ -31,7 +31,7 @@ func TestSpecSend(t *testing.T) {
 
 func TestSpecSendNil(t *testing.T) {
 	// A send on a nil channel blocks forever.
-	var ch *Channel[int]
+	var ch Channel[int]
 	done := make(chan struct{})
 	go func() {
 		ch.Send(1)
@@ -47,7 +47,7 @@ func TestSpecSendNil(t *testing.T) {
 
 func TestSpecReceiveNil(t *testing.T) {
 	// Receiving from a nil channel blocks forever.
-	var ch *Channel[int]
+	var ch Channel[int]
 	done := make(chan struct{})
 	go func() {
 		ch.Receive()
@@ -76,7 +76,7 @@ func TestSpecClose(t *testing.T) {
 	})
 	// Closing the nil channel also causes a run-time panic.
 	assert.Panics(func() {
-		var c *Channel[bool]
+		var c Channel[bool]
 		c.Close()
 	})
 	// After calling close, and after any previously sent values have been

--- a/model/go_channel/channel_spec_test.go
+++ b/model/go_channel/channel_spec_test.go
@@ -1,0 +1,98 @@
+package go_channel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests based on interpreting the text in the Go specification (see
+// https://go.dev/ref/spec#Send_statements,
+// https://go.dev/ref/spec#Receive_operator, and https://go.dev/ref/spec#Close
+// in particular).
+
+func TestSpecSend(t *testing.T) {
+	// A send on an unbuffered channel can proceed if a receiver is ready.
+	{
+		ch := NewChannel[int](0)
+		go func() {
+			ch.Receive()
+		}()
+		ch.Send(1)
+		// should not block forever
+	}
+	// A send on a buffered channel can proceed if there is room in the buffer.
+	{
+		ch := NewChannel[int](1)
+		ch.Send(1)
+	}
+}
+
+func TestSpecSendNil(t *testing.T) {
+	// A send on a nil channel blocks forever.
+	var ch *Channel[int]
+	done := make(chan struct{})
+	go func() {
+		ch.Send(1)
+		close(done)
+	}()
+	select {
+	case <-done:
+		panic("send should block forever")
+	case <-time.After(500 * time.Millisecond):
+		// good, blocked for at least 500ms
+	}
+}
+
+func TestSpecReceiveNil(t *testing.T) {
+	// Receiving from a nil channel blocks forever.
+	var ch *Channel[int]
+	done := make(chan struct{})
+	go func() {
+		ch.Receive()
+		close(done)
+	}()
+	select {
+	case <-done:
+		panic("receive should block forever")
+	case <-time.After(500 * time.Millisecond):
+		// good, blocked for at least 500ms
+	}
+}
+
+func TestSpecClose(t *testing.T) {
+	assert := assert.New(t)
+	// Sending to or closing a closed channel causes a run-time panic.
+	assert.Panics(func() {
+		c := NewChannel[int](0)
+		c.Close()
+		c.Send(1)
+	})
+	assert.Panics(func() {
+		c := NewChannel[int](0)
+		c.Close()
+		c.Close()
+	})
+	// Closing the nil channel also causes a run-time panic.
+	assert.Panics(func() {
+		var c *Channel[bool]
+		c.Close()
+	})
+	// After calling close, and after any previously sent values have been
+	// received, receive operations will return the zero value for the channel's
+	// type without blocking. The multi-valued receive operation returns a
+	// received value along with an indication of whether the channel is closed.
+	{
+		c := NewChannel[int](2)
+		c.Send(1)
+		c.Close()
+		v, ok := c.Receive()
+		if assert.True(ok) {
+			assert.Equal(1, v)
+		}
+		v, ok = c.Receive()
+		assert.False(ok)
+		assert.Equal(0, v)
+	}
+}

--- a/model/go_channel/channel_test.go
+++ b/model/go_channel/channel_test.go
@@ -1,0 +1,1226 @@
+package go_channel_test
+
+/*
+Tests to demonstrate Go's behavior on various subtle examples.
+*/
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/goose-lang/goose/model/go_channel"
+	"github.com/stretchr/testify/assert"
+)
+
+// The channel tests below are for the Go channel wrapper that uses built-in
+// channels. The tests are hand translated versions of correctness based tests in
+// https://go.dev/src/runtime/chan_test.go https://go.dev/src/runtime/chanbarrier_test.go
+func TestChan(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(4))
+	var N int = 200
+	if testing.Short() {
+		N = 20
+	}
+	for chanCap := 0; chanCap < N; chanCap++ {
+		{
+			// Ensure that receive from empty chan blocks.
+			c := go_channel.NewChannel[int](chanCap)
+			recv1 := false
+			go func() {
+				_, _ = c.Receive()
+				recv1 = true
+			}()
+			recv2 := false
+			go func() {
+				_, _ = c.Receive()
+				recv2 = true
+			}()
+			time.Sleep(time.Millisecond)
+			if recv1 || recv2 {
+				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
+			}
+			// Ensure that non-blocking receive does not block.
+
+			selected, _, _ := c.TryReceive(false)
+			if selected {
+				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
+			}
+
+			selected, _, _ = c.TryReceive(false)
+			if selected {
+				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
+			}
+			c.Send(0)
+			c.Send(0)
+		}
+
+		{
+			// Ensure that send to full chan blocks.
+			c := go_channel.NewChannel[int](chanCap)
+			for i := 0; i < chanCap; i++ {
+				c.Send(i)
+			}
+			sent := uint32(0)
+			go func() {
+				c.Send(0)
+				atomic.StoreUint32(&sent, 1)
+			}()
+			time.Sleep(time.Millisecond)
+			if atomic.LoadUint32(&sent) != 0 {
+				t.Fatalf("chan[%d]: send to full chan", chanCap)
+			}
+			selected, _, _ := go_channel.NonBlockingSelect1(c, go_channel.SelectSend, 0)
+			if selected {
+				t.Fatalf("chan[%d]: send to full chan", chanCap)
+			}
+			c.Receive()
+		}
+
+		{
+			// Ensure that we receive 0 from closed chan.
+			c := go_channel.NewChannel[int](chanCap)
+			for i := 0; i < chanCap; i++ {
+				c.Send(i)
+			}
+			c.Close()
+			for i := 0; i < chanCap; i++ {
+				v, _ := c.Receive()
+				if v != i {
+					t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, i)
+				}
+			}
+			if v, _ := c.Receive(); v != 0 {
+				t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, 0)
+			}
+			if v, ok := c.Receive(); v != 0 || ok {
+				t.Fatalf("chan[%d]: received %v/%v, expected %v/%v", chanCap, v, ok, 0, false)
+			}
+		}
+
+		{
+			// Ensure that close unblocks receive.
+			c := go_channel.NewChannel[int](chanCap)
+			done := go_channel.NewChannel[bool](0)
+			go func() {
+				v, ok := c.Receive()
+				done.Send(v == 0 && ok == false)
+			}()
+			time.Sleep(time.Millisecond)
+			c.Close()
+			actually_done, _ := done.Receive()
+			if !actually_done {
+				t.Fatalf("chan[%d]: received non zero from closed chan", chanCap)
+			}
+		}
+
+		{
+			// Send 100 integers,
+			// ensure that we receive them non-corrupted in FIFO order.
+			c := go_channel.NewChannel[int](chanCap)
+			go func() {
+				for i := 0; i < 100; i++ {
+					c.Send(i)
+				}
+			}()
+			for i := 0; i < 100; i++ {
+				v, _ := c.Receive()
+				if v != i {
+					t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, i)
+				}
+			}
+
+			// Same, but using recv2.
+			go func() {
+				for i := 0; i < 100; i++ {
+					c.Send(i)
+				}
+			}()
+			for i := 0; i < 100; i++ {
+				v, ok := c.Receive()
+				if !ok {
+					t.Fatalf("chan[%d]: receive failed, expected %v", chanCap, i)
+				}
+				if v != i {
+					t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, i)
+				}
+			}
+
+			// Send 1000 integers in 4 goroutines,
+			// ensure that we receive what we send.
+			const P = 4
+			const L int = 1000
+			for p := 0; p < P; p++ {
+				go func() {
+					for i := 0; i < L; i++ {
+						c.Send(i)
+					}
+				}()
+			}
+			done := go_channel.NewChannel[map[int]int](chanCap)
+			for p := 0; p < P; p++ {
+				go func() {
+					recv := make(map[int]int)
+					for i := 0; i < L; i++ {
+						v, _ := c.Receive()
+						recv[v] = recv[v] + 1
+					}
+					done.Send(recv)
+				}()
+			}
+			recv := make(map[int]int)
+			for p := 0; p < P; p++ {
+				received_val, _ := done.Receive()
+				for k, v := range received_val {
+					recv[k] = recv[k] + v
+				}
+			}
+			if len(recv) != L {
+				t.Fatalf("chan[%d]: received %v values, expected %v", chanCap, len(recv), L)
+			}
+			for _, v := range recv {
+				if v != P {
+					t.Fatalf("chan[%d]: received %v values, expected %v", chanCap, v, P)
+				}
+			}
+		}
+
+		{
+			// Test len/cap.
+			c := go_channel.NewChannel[int](chanCap)
+			if c.Len() != 0 || c.Cap() != chanCap {
+				t.Fatalf("chan[%d]: bad len/cap, expect %v/%v, got %v/%v", chanCap, 0, chanCap, c.Len(), c.Cap())
+			}
+			for i := 0; i < chanCap; i++ {
+				c.Send(i)
+			}
+			if c.Len() != chanCap || c.Cap() != chanCap {
+				t.Fatalf("chan[%d]: bad len/cap, expect %v/%v, got %v/%v", chanCap, chanCap, chanCap, c.Len(), c.Cap())
+			}
+		}
+	}
+}
+
+// This just makes sure that we have the same semantics for len and cap. I don't
+// think we plan on doing much with these, but if we do, might as well get it right
+func TestLenCapComparedWithGoChannels(t *testing.T) {
+	capacities := []int{0, 1, 2, 5, 10}
+
+	for _, capacity := range capacities {
+		t.Run(fmt.Sprintf("Capacity%d", capacity), func(t *testing.T) {
+			// Create both channel types
+			goChan := make(chan int, capacity)
+			ourChan := go_channel.NewChannel[int](capacity)
+
+			// Test initial state
+			goLen := len(goChan)
+			goCap := cap(goChan)
+			ourLen := int(ourChan.Len())
+			ourCap := int(ourChan.Cap())
+
+			if goLen != ourLen || goCap != ourCap {
+				t.Errorf("Initial state mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+					goLen, goCap, ourLen, ourCap)
+			}
+
+			// Test after adding items
+			itemsToAdd := capacity
+			if capacity == 0 {
+				itemsToAdd = 0
+			} else {
+				for i := 0; i < capacity; i++ {
+					goChan <- int(i)
+					ourChan.Send(int(i))
+				}
+
+				goLen = len(goChan)
+				goCap = cap(goChan)
+				ourLen = int(ourChan.Len())
+				ourCap = int(ourChan.Cap())
+
+				if goLen != ourLen || goCap != ourCap {
+					t.Errorf("After filling mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+						goLen, goCap, ourLen, ourCap)
+				}
+			}
+
+			// Test after removing half the items
+			if itemsToAdd > 0 {
+				itemsToRemove := itemsToAdd / 2
+				for i := 0; i < itemsToRemove; i++ {
+					<-goChan
+					ourChan.Receive()
+				}
+
+				goLen = len(goChan)
+				goCap = cap(goChan)
+				ourLen = int(ourChan.Len())
+				ourCap = int(ourChan.Cap())
+
+				if goLen != ourLen || goCap != ourCap {
+					t.Errorf("After partial removal mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+						goLen, goCap, ourLen, ourCap)
+				}
+			}
+
+			// Test after closing
+			// Need to drain remaining items first to compare fairly
+			if itemsToAdd > 0 {
+				remainingItems := itemsToAdd - (itemsToAdd / 2)
+				for i := 0; i < remainingItems; i++ {
+					<-goChan
+					ourChan.Receive()
+				}
+			}
+
+			close(goChan)
+			ourChan.Close()
+
+			goLen = len(goChan)
+			goCap = cap(goChan)
+			ourLen = int(ourChan.Len())
+			ourCap = int(ourChan.Cap())
+
+			if goLen != ourLen || goCap != ourCap {
+				t.Errorf("After closing mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+					goLen, goCap, ourLen, ourCap)
+			}
+		})
+	}
+
+	// Test special case: nil channel
+	t.Run("NilChannel", func(t *testing.T) {
+		var goChan chan int
+		var ourChan *go_channel.Channel[int]
+
+		goLen := len(goChan)
+		goCap := cap(goChan)
+		ourLen := int(ourChan.Len()) // Should return 0 for nil channel
+		ourCap := int(ourChan.Cap()) // Should return 0 for nil channel
+
+		if goLen != ourLen || goCap != ourCap {
+			t.Errorf("Nil channel mismatch: Go len/cap: %d/%d, Our len/cap: %d/%d",
+				goLen, goCap, ourLen, ourCap)
+		}
+	})
+}
+
+// Some extra dummy checks for blocking behavior. Nil blocking is checked as well
+func TestBlockingBehavior(t *testing.T) {
+	timeout := time.Millisecond * 10 // Reasonable timeout to check blocking behavior
+
+	t.Run("ReceiveFromEmptyBlocks", func(t *testing.T) {
+		c := go_channel.NewChannel[int](0) // Unbuffered channel
+
+		done := make(chan bool)
+		go func() {
+			_, _ = c.Receive() // This should block
+			done <- true
+		}()
+
+		select {
+		case <-done:
+			t.Error("Receive from empty channel didn't block as expected")
+		case <-time.After(timeout):
+			// If we reach here, the operation blocked as expected
+		}
+	})
+
+	t.Run("SendToFullBlocks", func(t *testing.T) {
+		c := go_channel.NewChannel[int](1) // Buffered channel with capacity 1
+		c.Send(42)                          // Fill the channel
+
+		done := make(chan bool)
+		go func() {
+			c.Send(43) // This should block
+			done <- true
+		}()
+
+		select {
+		case <-done:
+			t.Error("Send to full channel didn't block as expected")
+		case <-time.After(timeout):
+			// If we reach here, the operation blocked as expected
+		}
+
+		// Clean up
+		_, _ = c.Receive()
+		select {
+		case <-done:
+			// Expected - operation completes
+		case <-time.After(timeout):
+			t.Error("Send operation didn't complete after space became available")
+		}
+	})
+
+	// Test nil channel behavior
+	t.Run("NilChannelBlocks", func(t *testing.T) {
+		// Test nil channel send
+		t.Run("SendToNilBlocks", func(t *testing.T) {
+			// Compare with Go's behavior
+			var goChan chan int
+			var ourChan *go_channel.Channel[int] = nil
+
+			goBlocked := true
+			ourBlocked := true
+
+			// Test Go's behavior
+			goBlockDone := make(chan bool)
+			go func() {
+				goChan <- 42 // This should block
+				goBlockDone <- true
+			}()
+
+			// Test our implementation
+			ourBlockDone := make(chan bool)
+			go func() {
+				ourChan.Send(42) // This should block
+				ourBlockDone <- true
+			}()
+
+			// Check if both operations block
+			select {
+			case <-goBlockDone:
+				goBlocked = false
+				t.Error("Go's send to nil channel didn't block as expected")
+			case <-ourBlockDone:
+				ourBlocked = false
+				t.Error("Our send to nil channel didn't block as expected")
+			case <-time.After(timeout):
+				// Both blocked, which is expected
+			}
+
+			if !goBlocked || !ourBlocked {
+				t.Errorf("Nil channel send blocking behavior mismatch: Go blocked: %v, Our blocked: %v",
+					goBlocked, ourBlocked)
+			}
+		})
+
+		// Test nil channel receive
+		t.Run("ReceiveFromNilBlocks", func(t *testing.T) {
+			// Compare with Go's behavior
+			var goChan chan int
+			var ourChan *go_channel.Channel[int] = nil
+
+			goBlocked := true
+			ourBlocked := true
+
+			// Test Go's behavior
+			goBlockDone := make(chan bool)
+			go func() {
+				_ = <-goChan // This should block
+				goBlockDone <- true
+			}()
+
+			// Test our implementation
+			ourBlockDone := make(chan bool)
+			go func() {
+				_, _ = ourChan.Receive() // This should block
+				ourBlockDone <- true
+			}()
+
+			// Check if both operations block
+			select {
+			case <-goBlockDone:
+				goBlocked = false
+				t.Error("Go's receive from nil channel didn't block as expected")
+			case <-ourBlockDone:
+				ourBlocked = false
+				t.Error("Our receive from nil channel didn't block as expected")
+			case <-time.After(timeout):
+				// Both blocked, which is expected
+			}
+
+			if !goBlocked || !ourBlocked {
+				t.Errorf("Nil channel receive blocking behavior mismatch: Go blocked: %v, Our blocked: %v",
+					goBlocked, ourBlocked)
+			}
+		})
+	})
+}
+
+// Make sure the panic situations lead to panic in the model with the same message.
+func TestPanicComparedWithGoChannels(t *testing.T) {
+	// Helper function to check if an operation panics and capture the panic message
+	assertPanicsWithMessage := func(f func()) (didPanic bool, message string) {
+		defer func() {
+			if r := recover(); r != nil {
+				didPanic = true
+				message = fmt.Sprint(r)
+			}
+		}()
+		f()
+		return false, ""
+	}
+
+	// Test send on closed channel
+	t.Run("SendOnClosedChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		goChan := make(chan int, 1)
+		close(goChan)
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			goChan <- 42
+		})
+
+		// Test with our channel implementation
+		ourChan := go_channel.NewChannel[int](1)
+		ourChan.Close()
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.Send(42)
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "send on closed channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+
+	// Test close on closed channel
+	t.Run("CloseOnClosedChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		goChan := make(chan int, 1)
+		close(goChan)
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			close(goChan)
+		})
+
+		// Test with our channel implementation
+		ourChan := go_channel.NewChannel[int](1)
+		ourChan.Close()
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.Close()
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "close of closed channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+
+	// Test try-send on closed channel (using select with default for Go)
+	t.Run("TrySendOnClosedChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		goChan := make(chan int, 1)
+		close(goChan)
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			select {
+			case goChan <- 42:
+				// Should panic before reaching here
+			default:
+				// Should panic before reaching here
+			}
+		})
+
+		// Test with our channel implementation
+		ourChan := go_channel.NewChannel[int](1)
+		ourChan.Close()
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.TrySend(42, false)
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "send on closed channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+
+	// Test buffered try-send on closed channel
+	t.Run("BufferedTrySendOnClosedChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		goChan := make(chan int, 5)
+		close(goChan)
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			select {
+			case goChan <- 42:
+				// Should panic before reaching here
+			default:
+				// Should panic before reaching here
+			}
+		})
+
+		// Test with our channel implementation
+		ourChan := go_channel.NewChannel[int](5)
+		ourChan.Close()
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.TrySend(42, false)
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "send on closed channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+
+	// Test close of nil channel
+	t.Run("CloseNilChannel", func(t *testing.T) {
+		// Test with Go's native channel
+		var goChan chan int
+		goDidPanic, goMessage := assertPanicsWithMessage(func() {
+			close(goChan)
+		})
+
+		// Test with our channel implementation
+		var ourChan *go_channel.Channel[int]
+		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
+			ourChan.Close()
+		})
+
+		// Compare results
+		if goDidPanic != ourDidPanic {
+			t.Errorf("Behavior mismatch: Go channel panicked: %v, Our channel panicked: %v",
+				goDidPanic, ourDidPanic)
+		}
+
+		// Compare error messages
+		if goDidPanic && ourDidPanic {
+			if !strings.Contains(ourMessage, "close of nil channel") {
+				t.Errorf("Error message mismatch:\nGo message: %q\nOur message: %q",
+					goMessage, ourMessage)
+			}
+		}
+	})
+}
+
+func TestNonblockRecvRace(t *testing.T) {
+	var n int = 10000
+	if testing.Short() {
+		n = 100
+	}
+	for i := 0; i < n; i++ {
+		c := go_channel.NewChannel[int](1)
+		c.Send(1)
+		go func() {
+			selected, _, _ := go_channel.NonBlockingSelect1(c, go_channel.SelectRecv, 0)
+			if !selected {
+				t.Error("chan is not ready")
+			}
+		}()
+		c.Close()
+		c.Receive()
+		if t.Failed() {
+			return
+		}
+	}
+}
+func TestMultiConsumer(t *testing.T) {
+	const nwork int = 23
+	const niter int = 271828
+
+	pn := []int{2, 3, 7, 11, 13, 17, 19, 23, 27, 31}
+
+	q := go_channel.NewChannel[int](nwork * 3)
+	r := go_channel.NewChannel[int](nwork * 3)
+
+	// workers
+	var wg sync.WaitGroup
+	for i := 0; i < nwork; i++ {
+		wg.Add(1)
+		go func(w int) {
+			for val := range q.Iter() {
+				if pn[w%len(pn)] == val {
+					runtime.Gosched()
+				}
+				r.Send(val)
+			}
+			wg.Done()
+		}(i)
+	}
+
+	// feeder & closer
+	var expect int = 0
+	go func() {
+		for i := 0; i < niter; i++ {
+			v := pn[i%len(pn)]
+			expect += v
+			q.Send(v)
+		}
+		q.Close() // no more work
+		wg.Wait() // workers done
+		r.Close() // ... so there can be no more results
+	}()
+
+	// consume & check
+	var n int = 0
+	var s int = 0
+	for val := range r.Iter() {
+		n++
+		s += val
+	}
+	if n != niter || s != expect {
+		t.Errorf("Expected sum %d (got %d) from %d iter (saw %d)",
+			expect, s, niter, n)
+	}
+}
+
+type response struct {
+}
+
+type myError struct {
+}
+
+func (myError) Error() string { return "" }
+
+func doRequest(useSelect bool) (*response, error) {
+	type async struct {
+		resp *response
+		err  error
+	}
+	ch := go_channel.NewChannel[*async](0)
+	done := go_channel.NewChannel[struct{}](0)
+
+	if useSelect {
+		go func() {
+			selected_case, _, _, _ := go_channel.BlockingSelect2(ch, go_channel.SelectSend, &async{resp: nil, err: myError{}}, done, go_channel.SelectRecv, struct{}{})
+			// These cases don't actually do anything but wanted to stick with the intended
+			// translation throughout this file.
+			if selected_case == 0 {
+
+			} else if selected_case == 1 {
+
+			}
+		}()
+	} else {
+		go func() {
+			ch.Send(&async{resp: nil, err: myError{}})
+		}()
+	}
+
+	var r *async = ch.ReceiveDiscardOk()
+	runtime.Gosched()
+	return r.resp, r.err
+}
+
+func TestChanSendSelectBarrier(t *testing.T) {
+	t.Parallel()
+	testChanSendBarrier(true)
+}
+
+func TestChanSendBarrier(t *testing.T) {
+	t.Parallel()
+	testChanSendBarrier(false)
+}
+
+func testChanSendBarrier(useSelect bool) {
+	var wg sync.WaitGroup
+	outer := 2
+	inner := 20
+	for i := 0; i < outer; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var garbage []byte
+			for j := 0; j < inner; j++ {
+				_, err := doRequest(useSelect)
+				_, ok := err.(myError)
+				if !ok {
+					panic(1)
+				}
+				garbage = makeByte()
+			}
+			_ = garbage
+		}()
+	}
+	wg.Wait()
+}
+
+//go:noinline
+func makeByte() []byte {
+	return make([]byte, 1<<10)
+}
+
+// This test checks that select acts on the state of the channels at one
+// moment in the execution, not over a smeared time window.
+// In the test, one goroutine does:
+//
+//	create c1, c2
+//	make c1 ready for receiving
+//	create second goroutine
+//	make c2 ready for receiving
+//	make c1 no longer ready for receiving (if possible)
+//
+// The second goroutine does a non-blocking select receiving from c1 and c2.
+// From the time the second goroutine is created, at least one of c1 and c2
+// is always ready for receiving, so the select in the second goroutine must
+// always receive from one or the other. It must never execute the default case.
+func TestNonblockSelectRace(t *testing.T) {
+	n := 1000
+	done := go_channel.NewChannel[bool](0)
+	for i := 0; i < n; i++ {
+		c1 := go_channel.NewChannel[int](1)
+		c2 := go_channel.NewChannel[int](1)
+		c1.Send(1)
+		go func() {
+			selected_case, _, _, _ := go_channel.NonBlockingSelect2(c1, go_channel.SelectRecv, 0, c2, go_channel.SelectRecv, 0)
+			if selected_case == 0 {
+			}
+			if selected_case == 1 {
+
+			}
+			if selected_case == 2 {
+				done.Send(false)
+				return
+			}
+			done.Send(true)
+		}()
+		c2.Send(1)
+		c1.TryReceive(false)
+		val := done.ReceiveDiscardOk()
+		if !val {
+			t.Fatal("no chan is ready")
+		}
+	}
+}
+
+// Same as TestNonblockSelectRace, but close(c2) replaces c2 <- 1.
+func TestNonblockSelectRace2(t *testing.T) {
+	n := 1000
+	done := go_channel.NewChannel[bool](0)
+	for i := 0; i < n; i++ {
+		c1 := go_channel.NewChannel[int](1)
+		c2 := go_channel.NewChannel[int](1)
+		c1.Send(1)
+		go func() {
+			selected_case, _, _, _ := go_channel.NonBlockingSelect2(
+				c1, go_channel.SelectRecv, 0,
+				c2, go_channel.SelectRecv, 0)
+
+			if selected_case == 0 {
+			}
+			if selected_case == 1 {
+			}
+			if selected_case == 2 {
+				done.Send(false)
+				return
+			}
+			done.Send(true)
+		}()
+		c2.Close()
+		go_channel.NonBlockingSelect1(c1, go_channel.SelectRecv, 0)
+		val := done.ReceiveDiscardOk()
+		if !val {
+			t.Fatal("no chan is ready")
+		}
+	}
+}
+
+// Make sure that we can handle blocking select statements with matching send/receive
+// operations.
+func TestSelfSelect(t *testing.T) {
+	// Ensure that send/recv on the same chan in select
+	// does not crash nor deadlock.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
+	for _, chanCap := range []int{0, 10} {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		c := go_channel.NewChannel[int](chanCap)
+		for p := 0; p < 2; p++ {
+			p := p
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 1000; i++ {
+					if p == 0 || i%2 == 0 {
+						selected_case, _, recv_val, _ := go_channel.BlockingSelect2(
+							c, go_channel.SelectSend, p,
+							c, go_channel.SelectRecv, 0)
+						if selected_case == 0 {
+							break
+						} else if selected_case == 1 {
+							if chanCap == 0 && recv_val == p {
+								t.Errorf("self receive")
+								return
+							}
+							break
+						}
+					} else {
+						selected_case, recv_val, _, _ := go_channel.BlockingSelect2(
+							c, go_channel.SelectRecv, 0,
+							c, go_channel.SelectSend, p)
+						if selected_case == 0 {
+							if chanCap == 0 && recv_val == p {
+								t.Errorf("self receive")
+								return
+							}
+							break
+						} else if selected_case == 1 {
+							break
+						}
+					}
+				}
+			}()
+		}
+		wg.Wait()
+	}
+}
+
+// Make sure that a "perpetually selectable" closed receive case appearing first does not mean
+// it will be selected every time.
+func TestSelectLivenessOrder1(t *testing.T) {
+	c1 := go_channel.NewChannel[int](0)
+	c2 := go_channel.NewChannel[int](2)
+	c1.Close()
+	c2.Send(0)
+	c1_selected := false
+	c2_selected := false
+	for {
+		selected_case, _, _, _ := go_channel.NonBlockingSelect2(
+			c1, go_channel.SelectRecv, 0,
+			c2, go_channel.SelectRecv, 0)
+		// Make sure we eventually hit the second case
+		if selected_case == 0 {
+			c1_selected = true
+		} else if selected_case == 1 {
+			c2_selected = true
+		}
+		if c1_selected && c2_selected {
+			break
+		}
+	}
+}
+
+// Same as above but swap the case order to make sure it works symmetrically i.e. the
+// implementation doesn't have the same problem in the opposite order.
+func TestSelectLivenessOrder2(t *testing.T) {
+	c1 := go_channel.NewChannel[int](0)
+	c2 := go_channel.NewChannel[int](1)
+	c1.Close()
+	c2.Send(0)
+	c1_selected := false
+	c2_selected := false
+	for {
+		selected_case, _, _, _ := go_channel.NonBlockingSelect2(
+			c2, go_channel.SelectRecv, 0,
+			c1, go_channel.SelectRecv, 0)
+		// Make sure we eventually hit the second case
+		if selected_case == 0 {
+			c2_selected = true
+		} else if selected_case == 1 {
+			c1_selected = true
+		}
+		if c1_selected && c2_selected {
+			break
+		}
+	}
+}
+
+// Make sure if we keep selecting and 1 case is immediately selectable we still can choose a case
+// that eventually becomes selectable.
+func TestSelectLivenessNotImmediatelySelectable(t *testing.T) {
+	c1 := go_channel.NewChannel[int](0)
+	c2 := go_channel.NewChannel[int](0)
+	c1.Close()
+	c1_selected := false
+	c2_selected := false
+	go func() {
+		for {
+			selected_case, _, _, _ := go_channel.NonBlockingSelect2(
+				c2, go_channel.SelectRecv, 0,
+				c1, go_channel.SelectRecv, 0)
+			// Make sure we eventually hit the second case
+			if selected_case == 0 {
+				c2_selected = true
+			} else if selected_case == 1 {
+				c1_selected = true
+			}
+			if c1_selected && c2_selected {
+				break
+			}
+		}
+	}()
+	time.Sleep(time.Millisecond * 10)
+	c2.Send(0)
+}
+
+// Make sure a selectable buffered channel case isn't selected every time if it
+// appears first
+func TestSelectFairnessWithBufferedChannel(t *testing.T) {
+	// Create one buffered and one unbuffered channel
+	c1 := go_channel.NewChannel[int](1) // Buffered (capacity 1)
+	c2 := go_channel.NewChannel[int](0) // Unbuffered
+
+	// Put data in the buffered channel to make it immediately ready
+	c1.Send(42)
+
+	// Channel to signal test completion
+	done := go_channel.NewChannel[bool](0)
+	buffered_selected := false
+	unbuffered_selected := false
+
+	// Start a goroutine that selects until both channels have been chosen
+	go func() {
+		for {
+			selected_case, _, _, _ := go_channel.BlockingSelect2(
+				c1, go_channel.SelectRecv, 0,
+				c2, go_channel.SelectRecv, 0)
+			if selected_case == 0 {
+				buffered_selected = true
+				// Refill the buffered channel
+				c1.Send(42)
+			} else if selected_case == 1 {
+				unbuffered_selected = true
+			}
+			if buffered_selected && unbuffered_selected {
+				done.Send(true)
+				return
+			}
+		}
+	}()
+
+	// Send to the unbuffered channel
+	c2.Send(99)
+
+	// Wait for the test to complete
+	result := done.ReceiveDiscardOk()
+
+	// The done channel will only receive a value if both channels were selected
+	if !result {
+		t.Fatal("Test did not complete successfully")
+	}
+}
+func TestSelect1(t *testing.T) {
+	// One buffered channel so we can preload it without blocking
+	c1 := go_channel.NewChannel[int](1) // capacity=1
+	// preload c1
+	c1.Send(66)
+
+	// non-blocking: should pick the first case (index 0)
+	selected, recv_val, ok := go_channel.NonBlockingSelect1(c1, go_channel.SelectRecv, 0)
+	if !selected {
+		t.Error("expected selected")
+	}
+
+	// and confirm the values were returned correctly
+	if recv_val != 66 {
+		t.Errorf("expected recv_val=66, got %v", recv_val)
+	}
+	if !ok {
+		t.Error("expected ok=true, got false")
+	}
+
+	// Create a new empty channel for testing non-blocking behavior
+	emptyC1 := go_channel.NewChannel[int](1)
+
+	// With blocking=false and no selectable statement, should return selected=false
+	selected, _, _ = go_channel.NonBlockingSelect1(emptyC1, go_channel.SelectRecv, 0)
+	if selected {
+		t.Error("expected !selected when non-blocking with no available case")
+	}
+
+	// Close the channel and test receive on closed channel
+	emptyC1.Close()
+	selected, recv_val, ok = go_channel.NonBlockingSelect1(emptyC1, go_channel.SelectRecv, 0)
+	if !selected {
+		t.Error("expected selected for closed channel")
+	}
+	if ok {
+		t.Error("expected ok=false for closed channel, got true")
+	}
+	if recv_val != 0 {
+		t.Errorf("expected recv_val=0 (zero value) for closed channel, got %v", recv_val)
+	}
+}
+
+func TestSelect2(t *testing.T) {
+	// Two buffered channels so we can preload one without blocking
+	c1 := go_channel.NewChannel[int](1) // capacity=1
+	c2 := go_channel.NewChannel[int](1) // capacity=1
+	// preload c2
+	c2.Send(77)
+
+	// non-blocking: should pick the second case (index 1)
+	idx, val1, val2, ok := go_channel.NonBlockingSelect2(
+		c1, go_channel.SelectRecv, 0,
+		c2, go_channel.SelectRecv, 0)
+	if idx != 1 {
+		t.Errorf("expected selected index=1, got %d", idx)
+	}
+
+	// and confirm the values were returned correctly
+	if val2 != 77 {
+		t.Errorf("expected val2=77, got %v", val2)
+	}
+	if !ok {
+		t.Error("expected ok=true, got false")
+	}
+
+	// Create new empty channels for testing non-blocking behavior
+	emptyC1 := go_channel.NewChannel[int](1)
+	emptyC2 := go_channel.NewChannel[int](1)
+
+	// With blocking=false and no selectable statement, should return DefaultCase
+	idx, _, _, _ = go_channel.NonBlockingSelect2(
+		emptyC1, go_channel.SelectRecv, 0,
+		emptyC2, go_channel.SelectRecv, 0)
+	if idx != 2 {
+		t.Errorf("expected selected index=2 when non-blocking with no available case, got %d", idx)
+	}
+
+	// Close a channel and test receive on closed channel
+	emptyC1.Close()
+	idx, val1, _, ok = go_channel.BlockingSelect2(
+		emptyC1, go_channel.SelectRecv, 0,
+		emptyC2, go_channel.SelectRecv, 0)
+	if idx != 0 {
+		t.Errorf("expected selected index=0 for closed channel, got %d", idx)
+	}
+	if ok {
+		t.Error("expected ok=false for closed channel, got true")
+	}
+	if val1 != 0 {
+		t.Errorf("expected val1=0 (zero value) for closed channel, got %v", val1)
+	}
+}
+
+func TestSelect3(t *testing.T) {
+	// Three buffered channels so we can preload one without blocking
+	c1 := go_channel.NewChannel[int](1) // capacity=1
+	c2 := go_channel.NewChannel[int](1) // capacity=1
+	c3 := go_channel.NewChannel[int](1) // capacity=1
+	// preload c3
+	c3.Send(88)
+
+	// non-blocking: should pick the third case (index 2)
+	idx, _, val2, val3, ok := go_channel.NonBlockingSelect3(
+		c1, go_channel.SelectRecv, 0,
+		c2, go_channel.SelectRecv, 0,
+		c3, go_channel.SelectRecv, 0)
+	if idx != 2 {
+		t.Errorf("expected selected index=2, got %d", idx)
+	}
+
+	// and confirm the values were returned correctly
+	if val3 != 88 {
+		t.Errorf("expected val3=88, got %v", val3)
+	}
+	if !ok {
+		t.Error("expected ok=true, got false")
+	}
+
+	// Create new empty channels for testing non-blocking behavior
+	emptyC1 := go_channel.NewChannel[int](1)
+	emptyC2 := go_channel.NewChannel[int](1)
+	emptyC3 := go_channel.NewChannel[int](1)
+
+	// With blocking=false and no selectable statement, should return DefaultCase
+	idx, _, _, _, _ = go_channel.NonBlockingSelect3(
+		emptyC1, go_channel.SelectRecv, 0,
+		emptyC2, go_channel.SelectRecv, 0,
+		emptyC3, go_channel.SelectRecv, 0)
+	if idx != 3 {
+		t.Errorf("expected selected index=3 when non-blocking with no available case, got %d", idx)
+	}
+
+	// Close a channel and test receive on closed channel
+	emptyC2.Close()
+	idx, _, val2, _, ok = go_channel.BlockingSelect3(
+		emptyC1, go_channel.SelectRecv, 0,
+		emptyC2, go_channel.SelectRecv, 0,
+		emptyC3, go_channel.SelectRecv, 0)
+	if idx != 1 {
+		t.Errorf("expected selected index=1 for closed channel, got %d", idx)
+	}
+	if ok {
+		t.Error("expected ok=false for closed channel, got true")
+	}
+	if val2 != 0 {
+		t.Errorf("expected val2=0 (zero value) for closed channel, got %v", val2)
+	}
+}
+
+// Two non blocking selects should not match up.
+func Test2NBSelectNoProgress(t *testing.T) {
+	c1 := go_channel.NewChannel[int](0)
+
+	// Run the receiver loop in a goroutine
+	doneRecv := make(chan struct{})
+	go func() {
+		for {
+			selected, _, _ := go_channel.NonBlockingSelect1(c1, go_channel.SelectRecv, 0)
+			if selected {
+				break
+			}
+		}
+		close(doneRecv)
+	}()
+
+	// Run the sender loop in this goroutine
+	doneSend := make(chan struct{})
+	go func() {
+		for {
+			selected, _, _ := go_channel.NonBlockingSelect1(c1, go_channel.SelectSend, 0)
+			if selected {
+				break
+			}
+		}
+		close(doneSend)
+	}()
+
+	// Use a timeout: test passes if both loops never make progress
+	timeout := time.After(2 * time.Second)
+	select {
+	case <-doneRecv:
+		t.Fatal("unexpected progress in recv loop: expected to block")
+	case <-doneSend:
+		t.Fatal("unexpected progress in send loop: expected to block")
+	case <-timeout:
+		// Good: timeout reached, nothing made progress
+	}
+}
+
+func TestIter(t *testing.T) {
+	c := go_channel.NewChannel[int](0)
+	expected := make([]int, 0)
+	for i := range 10 {
+		expected = append(expected, i*10)
+	}
+	go func() {
+		for _, i := range expected {
+			c.Send(i)
+		}
+		c.Close()
+	}()
+	actual := make([]int, 0)
+	for val := range c.Iter() {
+		actual = append(actual, val)
+	}
+	assert.Equalf(t, expected, actual, "wrong values")
+}

--- a/model/go_channel/channel_test.go
+++ b/model/go_channel/channel_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goose-lang/goose/model/go_channel"
+	channel "github.com/goose-lang/goose/model/go_channel"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +29,7 @@ func TestChan(t *testing.T) {
 	for chanCap := 0; chanCap < N; chanCap++ {
 		{
 			// Ensure that receive from empty chan blocks.
-			c := go_channel.NewChannel[int](chanCap)
+			c := channel.NewChannel[int](chanCap)
 			recv1 := false
 			go func() {
 				_, _ = c.Receive()
@@ -61,7 +61,7 @@ func TestChan(t *testing.T) {
 
 		{
 			// Ensure that send to full chan blocks.
-			c := go_channel.NewChannel[int](chanCap)
+			c := channel.NewChannel[int](chanCap)
 			for i := 0; i < chanCap; i++ {
 				c.Send(i)
 			}
@@ -74,7 +74,7 @@ func TestChan(t *testing.T) {
 			if atomic.LoadUint32(&sent) != 0 {
 				t.Fatalf("chan[%d]: send to full chan", chanCap)
 			}
-			selected, _, _ := go_channel.NonBlockingSelect1(c, go_channel.SelectSend, 0)
+			selected, _, _ := channel.NonBlockingSelect1(c, channel.SelectSend, 0)
 			if selected {
 				t.Fatalf("chan[%d]: send to full chan", chanCap)
 			}
@@ -83,7 +83,7 @@ func TestChan(t *testing.T) {
 
 		{
 			// Ensure that we receive 0 from closed chan.
-			c := go_channel.NewChannel[int](chanCap)
+			c := channel.NewChannel[int](chanCap)
 			for i := 0; i < chanCap; i++ {
 				c.Send(i)
 			}
@@ -104,8 +104,8 @@ func TestChan(t *testing.T) {
 
 		{
 			// Ensure that close unblocks receive.
-			c := go_channel.NewChannel[int](chanCap)
-			done := go_channel.NewChannel[bool](0)
+			c := channel.NewChannel[int](chanCap)
+			done := channel.NewChannel[bool](0)
 			go func() {
 				v, ok := c.Receive()
 				done.Send(v == 0 && ok == false)
@@ -121,7 +121,7 @@ func TestChan(t *testing.T) {
 		{
 			// Send 100 integers,
 			// ensure that we receive them non-corrupted in FIFO order.
-			c := go_channel.NewChannel[int](chanCap)
+			c := channel.NewChannel[int](chanCap)
 			go func() {
 				for i := 0; i < 100; i++ {
 					c.Send(i)
@@ -161,7 +161,7 @@ func TestChan(t *testing.T) {
 					}
 				}()
 			}
-			done := go_channel.NewChannel[map[int]int](chanCap)
+			done := channel.NewChannel[map[int]int](chanCap)
 			for p := 0; p < P; p++ {
 				go func() {
 					recv := make(map[int]int)
@@ -191,7 +191,7 @@ func TestChan(t *testing.T) {
 
 		{
 			// Test len/cap.
-			c := go_channel.NewChannel[int](chanCap)
+			c := channel.NewChannel[int](chanCap)
 			if c.Len() != 0 || c.Cap() != chanCap {
 				t.Fatalf("chan[%d]: bad len/cap, expect %v/%v, got %v/%v", chanCap, 0, chanCap, c.Len(), c.Cap())
 			}
@@ -214,7 +214,7 @@ func TestLenCapComparedWithGoChannels(t *testing.T) {
 		t.Run(fmt.Sprintf("Capacity%d", capacity), func(t *testing.T) {
 			// Create both channel types
 			goChan := make(chan int, capacity)
-			ourChan := go_channel.NewChannel[int](capacity)
+			ourChan := channel.NewChannel[int](capacity)
 
 			// Test initial state
 			goLen := len(goChan)
@@ -295,7 +295,7 @@ func TestLenCapComparedWithGoChannels(t *testing.T) {
 	// Test special case: nil channel
 	t.Run("NilChannel", func(t *testing.T) {
 		var goChan chan int
-		var ourChan go_channel.Channel[int]
+		var ourChan channel.Channel[int]
 
 		goLen := len(goChan)
 		goCap := cap(goChan)
@@ -314,7 +314,7 @@ func TestBlockingBehavior(t *testing.T) {
 	timeout := time.Millisecond * 10 // Reasonable timeout to check blocking behavior
 
 	t.Run("ReceiveFromEmptyBlocks", func(t *testing.T) {
-		c := go_channel.NewChannel[int](0) // Unbuffered channel
+		c := channel.NewChannel[int](0) // Unbuffered channel
 
 		done := make(chan bool)
 		go func() {
@@ -331,8 +331,8 @@ func TestBlockingBehavior(t *testing.T) {
 	})
 
 	t.Run("SendToFullBlocks", func(t *testing.T) {
-		c := go_channel.NewChannel[int](1) // Buffered channel with capacity 1
-		c.Send(42)                          // Fill the channel
+		c := channel.NewChannel[int](1) // Buffered channel with capacity 1
+		c.Send(42)                      // Fill the channel
 
 		done := make(chan bool)
 		go func() {
@@ -363,7 +363,7 @@ func TestBlockingBehavior(t *testing.T) {
 		t.Run("SendToNilBlocks", func(t *testing.T) {
 			// Compare with Go's behavior
 			var goChan chan int
-			var ourChan go_channel.Channel[int] = nil
+			var ourChan channel.Channel[int] = nil
 
 			goBlocked := true
 			ourBlocked := true
@@ -404,7 +404,7 @@ func TestBlockingBehavior(t *testing.T) {
 		t.Run("ReceiveFromNilBlocks", func(t *testing.T) {
 			// Compare with Go's behavior
 			var goChan chan int
-			var ourChan go_channel.Channel[int] = nil
+			var ourChan channel.Channel[int] = nil
 
 			goBlocked := true
 			ourBlocked := true
@@ -467,7 +467,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		ourChan := go_channel.NewChannel[int](1)
+		ourChan := channel.NewChannel[int](1)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.Send(42)
@@ -498,7 +498,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		ourChan := go_channel.NewChannel[int](1)
+		ourChan := channel.NewChannel[int](1)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.Close()
@@ -534,7 +534,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		ourChan := go_channel.NewChannel[int](1)
+		ourChan := channel.NewChannel[int](1)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.TrySend(42, false)
@@ -570,7 +570,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		ourChan := go_channel.NewChannel[int](5)
+		ourChan := channel.NewChannel[int](5)
 		ourChan.Close()
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.TrySend(42, false)
@@ -600,7 +600,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		var ourChan go_channel.Channel[int]
+		var ourChan channel.Channel[int]
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.Close()
 		})
@@ -627,10 +627,10 @@ func TestNonblockRecvRace(t *testing.T) {
 		n = 100
 	}
 	for i := 0; i < n; i++ {
-		c := go_channel.NewChannel[int](1)
+		c := channel.NewChannel[int](1)
 		c.Send(1)
 		go func() {
-			selected, _, _ := go_channel.NonBlockingSelect1(c, go_channel.SelectRecv, 0)
+			selected, _, _ := channel.NonBlockingSelect1(c, channel.SelectRecv, 0)
 			if !selected {
 				t.Error("chan is not ready")
 			}
@@ -648,8 +648,8 @@ func TestMultiConsumer(t *testing.T) {
 
 	pn := []int{2, 3, 7, 11, 13, 17, 19, 23, 27, 31}
 
-	q := go_channel.NewChannel[int](nwork * 3)
-	r := go_channel.NewChannel[int](nwork * 3)
+	q := channel.NewChannel[int](nwork * 3)
+	r := channel.NewChannel[int](nwork * 3)
 
 	// workers
 	var wg sync.WaitGroup
@@ -705,12 +705,12 @@ func doRequest(useSelect bool) (*response, error) {
 		resp *response
 		err  error
 	}
-	ch := go_channel.NewChannel[*async](0)
-	done := go_channel.NewChannel[struct{}](0)
+	ch := channel.NewChannel[*async](0)
+	done := channel.NewChannel[struct{}](0)
 
 	if useSelect {
 		go func() {
-			selected_case, _, _, _ := go_channel.BlockingSelect2(ch, go_channel.SelectSend, &async{resp: nil, err: myError{}}, done, go_channel.SelectRecv, struct{}{})
+			selected_case, _, _, _ := channel.BlockingSelect2(ch, channel.SelectSend, &async{resp: nil, err: myError{}}, done, channel.SelectRecv, struct{}{})
 			// These cases don't actually do anything but wanted to stick with the intended
 			// translation throughout this file.
 			if selected_case == 0 {
@@ -784,13 +784,13 @@ func makeByte() []byte {
 // always receive from one or the other. It must never execute the default case.
 func TestNonblockSelectRace(t *testing.T) {
 	n := 1000
-	done := go_channel.NewChannel[bool](0)
+	done := channel.NewChannel[bool](0)
 	for i := 0; i < n; i++ {
-		c1 := go_channel.NewChannel[int](1)
-		c2 := go_channel.NewChannel[int](1)
+		c1 := channel.NewChannel[int](1)
+		c2 := channel.NewChannel[int](1)
 		c1.Send(1)
 		go func() {
-			selected_case, _, _, _ := go_channel.NonBlockingSelect2(c1, go_channel.SelectRecv, 0, c2, go_channel.SelectRecv, 0)
+			selected_case, _, _, _ := channel.NonBlockingSelect2(c1, channel.SelectRecv, 0, c2, channel.SelectRecv, 0)
 			if selected_case == 0 {
 			}
 			if selected_case == 1 {
@@ -814,15 +814,15 @@ func TestNonblockSelectRace(t *testing.T) {
 // Same as TestNonblockSelectRace, but close(c2) replaces c2 <- 1.
 func TestNonblockSelectRace2(t *testing.T) {
 	n := 1000
-	done := go_channel.NewChannel[bool](0)
+	done := channel.NewChannel[bool](0)
 	for i := 0; i < n; i++ {
-		c1 := go_channel.NewChannel[int](1)
-		c2 := go_channel.NewChannel[int](1)
+		c1 := channel.NewChannel[int](1)
+		c2 := channel.NewChannel[int](1)
 		c1.Send(1)
 		go func() {
-			selected_case, _, _, _ := go_channel.NonBlockingSelect2(
-				c1, go_channel.SelectRecv, 0,
-				c2, go_channel.SelectRecv, 0)
+			selected_case, _, _, _ := channel.NonBlockingSelect2(
+				c1, channel.SelectRecv, 0,
+				c2, channel.SelectRecv, 0)
 
 			if selected_case == 0 {
 			}
@@ -835,7 +835,7 @@ func TestNonblockSelectRace2(t *testing.T) {
 			done.Send(true)
 		}()
 		c2.Close()
-		go_channel.NonBlockingSelect1(c1, go_channel.SelectRecv, 0)
+		channel.NonBlockingSelect1(c1, channel.SelectRecv, 0)
 		val := done.ReceiveDiscardOk()
 		if !val {
 			t.Fatal("no chan is ready")
@@ -852,16 +852,16 @@ func TestSelfSelect(t *testing.T) {
 	for _, chanCap := range []int{0, 10} {
 		var wg sync.WaitGroup
 		wg.Add(2)
-		c := go_channel.NewChannel[int](chanCap)
+		c := channel.NewChannel[int](chanCap)
 		for p := 0; p < 2; p++ {
 			p := p
 			go func() {
 				defer wg.Done()
 				for i := 0; i < 1000; i++ {
 					if p == 0 || i%2 == 0 {
-						selected_case, _, recv_val, _ := go_channel.BlockingSelect2(
-							c, go_channel.SelectSend, p,
-							c, go_channel.SelectRecv, 0)
+						selected_case, _, recv_val, _ := channel.BlockingSelect2(
+							c, channel.SelectSend, p,
+							c, channel.SelectRecv, 0)
 						if selected_case == 0 {
 							break
 						} else if selected_case == 1 {
@@ -872,9 +872,9 @@ func TestSelfSelect(t *testing.T) {
 							break
 						}
 					} else {
-						selected_case, recv_val, _, _ := go_channel.BlockingSelect2(
-							c, go_channel.SelectRecv, 0,
-							c, go_channel.SelectSend, p)
+						selected_case, recv_val, _, _ := channel.BlockingSelect2(
+							c, channel.SelectRecv, 0,
+							c, channel.SelectSend, p)
 						if selected_case == 0 {
 							if chanCap == 0 && recv_val == p {
 								t.Errorf("self receive")
@@ -895,16 +895,16 @@ func TestSelfSelect(t *testing.T) {
 // Make sure that a "perpetually selectable" closed receive case appearing first does not mean
 // it will be selected every time.
 func TestSelectLivenessOrder1(t *testing.T) {
-	c1 := go_channel.NewChannel[int](0)
-	c2 := go_channel.NewChannel[int](2)
+	c1 := channel.NewChannel[int](0)
+	c2 := channel.NewChannel[int](2)
 	c1.Close()
 	c2.Send(0)
 	c1_selected := false
 	c2_selected := false
 	for {
-		selected_case, _, _, _ := go_channel.NonBlockingSelect2(
-			c1, go_channel.SelectRecv, 0,
-			c2, go_channel.SelectRecv, 0)
+		selected_case, _, _, _ := channel.NonBlockingSelect2(
+			c1, channel.SelectRecv, 0,
+			c2, channel.SelectRecv, 0)
 		// Make sure we eventually hit the second case
 		if selected_case == 0 {
 			c1_selected = true
@@ -920,16 +920,16 @@ func TestSelectLivenessOrder1(t *testing.T) {
 // Same as above but swap the case order to make sure it works symmetrically i.e. the
 // implementation doesn't have the same problem in the opposite order.
 func TestSelectLivenessOrder2(t *testing.T) {
-	c1 := go_channel.NewChannel[int](0)
-	c2 := go_channel.NewChannel[int](1)
+	c1 := channel.NewChannel[int](0)
+	c2 := channel.NewChannel[int](1)
 	c1.Close()
 	c2.Send(0)
 	c1_selected := false
 	c2_selected := false
 	for {
-		selected_case, _, _, _ := go_channel.NonBlockingSelect2(
-			c2, go_channel.SelectRecv, 0,
-			c1, go_channel.SelectRecv, 0)
+		selected_case, _, _, _ := channel.NonBlockingSelect2(
+			c2, channel.SelectRecv, 0,
+			c1, channel.SelectRecv, 0)
 		// Make sure we eventually hit the second case
 		if selected_case == 0 {
 			c2_selected = true
@@ -945,16 +945,16 @@ func TestSelectLivenessOrder2(t *testing.T) {
 // Make sure if we keep selecting and 1 case is immediately selectable we still can choose a case
 // that eventually becomes selectable.
 func TestSelectLivenessNotImmediatelySelectable(t *testing.T) {
-	c1 := go_channel.NewChannel[int](0)
-	c2 := go_channel.NewChannel[int](0)
+	c1 := channel.NewChannel[int](0)
+	c2 := channel.NewChannel[int](0)
 	c1.Close()
 	c1_selected := false
 	c2_selected := false
 	go func() {
 		for {
-			selected_case, _, _, _ := go_channel.NonBlockingSelect2(
-				c2, go_channel.SelectRecv, 0,
-				c1, go_channel.SelectRecv, 0)
+			selected_case, _, _, _ := channel.NonBlockingSelect2(
+				c2, channel.SelectRecv, 0,
+				c1, channel.SelectRecv, 0)
 			// Make sure we eventually hit the second case
 			if selected_case == 0 {
 				c2_selected = true
@@ -974,23 +974,23 @@ func TestSelectLivenessNotImmediatelySelectable(t *testing.T) {
 // appears first
 func TestSelectFairnessWithBufferedChannel(t *testing.T) {
 	// Create one buffered and one unbuffered channel
-	c1 := go_channel.NewChannel[int](1) // Buffered (capacity 1)
-	c2 := go_channel.NewChannel[int](0) // Unbuffered
+	c1 := channel.NewChannel[int](1) // Buffered (capacity 1)
+	c2 := channel.NewChannel[int](0) // Unbuffered
 
 	// Put data in the buffered channel to make it immediately ready
 	c1.Send(42)
 
 	// Channel to signal test completion
-	done := go_channel.NewChannel[bool](0)
+	done := channel.NewChannel[bool](0)
 	buffered_selected := false
 	unbuffered_selected := false
 
 	// Start a goroutine that selects until both channels have been chosen
 	go func() {
 		for {
-			selected_case, _, _, _ := go_channel.BlockingSelect2(
-				c1, go_channel.SelectRecv, 0,
-				c2, go_channel.SelectRecv, 0)
+			selected_case, _, _, _ := channel.BlockingSelect2(
+				c1, channel.SelectRecv, 0,
+				c2, channel.SelectRecv, 0)
 			if selected_case == 0 {
 				buffered_selected = true
 				// Refill the buffered channel
@@ -1018,12 +1018,12 @@ func TestSelectFairnessWithBufferedChannel(t *testing.T) {
 }
 func TestSelect1(t *testing.T) {
 	// One buffered channel so we can preload it without blocking
-	c1 := go_channel.NewChannel[int](1) // capacity=1
+	c1 := channel.NewChannel[int](1) // capacity=1
 	// preload c1
 	c1.Send(66)
 
 	// non-blocking: should pick the first case (index 0)
-	selected, recv_val, ok := go_channel.NonBlockingSelect1(c1, go_channel.SelectRecv, 0)
+	selected, recv_val, ok := channel.NonBlockingSelect1(c1, channel.SelectRecv, 0)
 	if !selected {
 		t.Error("expected selected")
 	}
@@ -1037,17 +1037,17 @@ func TestSelect1(t *testing.T) {
 	}
 
 	// Create a new empty channel for testing non-blocking behavior
-	emptyC1 := go_channel.NewChannel[int](1)
+	emptyC1 := channel.NewChannel[int](1)
 
 	// With blocking=false and no selectable statement, should return selected=false
-	selected, _, _ = go_channel.NonBlockingSelect1(emptyC1, go_channel.SelectRecv, 0)
+	selected, _, _ = channel.NonBlockingSelect1(emptyC1, channel.SelectRecv, 0)
 	if selected {
 		t.Error("expected !selected when non-blocking with no available case")
 	}
 
 	// Close the channel and test receive on closed channel
 	emptyC1.Close()
-	selected, recv_val, ok = go_channel.NonBlockingSelect1(emptyC1, go_channel.SelectRecv, 0)
+	selected, recv_val, ok = channel.NonBlockingSelect1(emptyC1, channel.SelectRecv, 0)
 	if !selected {
 		t.Error("expected selected for closed channel")
 	}
@@ -1061,15 +1061,15 @@ func TestSelect1(t *testing.T) {
 
 func TestSelect2(t *testing.T) {
 	// Two buffered channels so we can preload one without blocking
-	c1 := go_channel.NewChannel[int](1) // capacity=1
-	c2 := go_channel.NewChannel[int](1) // capacity=1
+	c1 := channel.NewChannel[int](1) // capacity=1
+	c2 := channel.NewChannel[int](1) // capacity=1
 	// preload c2
 	c2.Send(77)
 
 	// non-blocking: should pick the second case (index 1)
-	idx, val1, val2, ok := go_channel.NonBlockingSelect2(
-		c1, go_channel.SelectRecv, 0,
-		c2, go_channel.SelectRecv, 0)
+	idx, val1, val2, ok := channel.NonBlockingSelect2(
+		c1, channel.SelectRecv, 0,
+		c2, channel.SelectRecv, 0)
 	if idx != 1 {
 		t.Errorf("expected selected index=1, got %d", idx)
 	}
@@ -1083,22 +1083,22 @@ func TestSelect2(t *testing.T) {
 	}
 
 	// Create new empty channels for testing non-blocking behavior
-	emptyC1 := go_channel.NewChannel[int](1)
-	emptyC2 := go_channel.NewChannel[int](1)
+	emptyC1 := channel.NewChannel[int](1)
+	emptyC2 := channel.NewChannel[int](1)
 
 	// With blocking=false and no selectable statement, should return DefaultCase
-	idx, _, _, _ = go_channel.NonBlockingSelect2(
-		emptyC1, go_channel.SelectRecv, 0,
-		emptyC2, go_channel.SelectRecv, 0)
+	idx, _, _, _ = channel.NonBlockingSelect2(
+		emptyC1, channel.SelectRecv, 0,
+		emptyC2, channel.SelectRecv, 0)
 	if idx != 2 {
 		t.Errorf("expected selected index=2 when non-blocking with no available case, got %d", idx)
 	}
 
 	// Close a channel and test receive on closed channel
 	emptyC1.Close()
-	idx, val1, _, ok = go_channel.BlockingSelect2(
-		emptyC1, go_channel.SelectRecv, 0,
-		emptyC2, go_channel.SelectRecv, 0)
+	idx, val1, _, ok = channel.BlockingSelect2(
+		emptyC1, channel.SelectRecv, 0,
+		emptyC2, channel.SelectRecv, 0)
 	if idx != 0 {
 		t.Errorf("expected selected index=0 for closed channel, got %d", idx)
 	}
@@ -1112,17 +1112,17 @@ func TestSelect2(t *testing.T) {
 
 func TestSelect3(t *testing.T) {
 	// Three buffered channels so we can preload one without blocking
-	c1 := go_channel.NewChannel[int](1) // capacity=1
-	c2 := go_channel.NewChannel[int](1) // capacity=1
-	c3 := go_channel.NewChannel[int](1) // capacity=1
+	c1 := channel.NewChannel[int](1) // capacity=1
+	c2 := channel.NewChannel[int](1) // capacity=1
+	c3 := channel.NewChannel[int](1) // capacity=1
 	// preload c3
 	c3.Send(88)
 
 	// non-blocking: should pick the third case (index 2)
-	idx, _, val2, val3, ok := go_channel.NonBlockingSelect3(
-		c1, go_channel.SelectRecv, 0,
-		c2, go_channel.SelectRecv, 0,
-		c3, go_channel.SelectRecv, 0)
+	idx, _, val2, val3, ok := channel.NonBlockingSelect3(
+		c1, channel.SelectRecv, 0,
+		c2, channel.SelectRecv, 0,
+		c3, channel.SelectRecv, 0)
 	if idx != 2 {
 		t.Errorf("expected selected index=2, got %d", idx)
 	}
@@ -1136,25 +1136,25 @@ func TestSelect3(t *testing.T) {
 	}
 
 	// Create new empty channels for testing non-blocking behavior
-	emptyC1 := go_channel.NewChannel[int](1)
-	emptyC2 := go_channel.NewChannel[int](1)
-	emptyC3 := go_channel.NewChannel[int](1)
+	emptyC1 := channel.NewChannel[int](1)
+	emptyC2 := channel.NewChannel[int](1)
+	emptyC3 := channel.NewChannel[int](1)
 
 	// With blocking=false and no selectable statement, should return DefaultCase
-	idx, _, _, _, _ = go_channel.NonBlockingSelect3(
-		emptyC1, go_channel.SelectRecv, 0,
-		emptyC2, go_channel.SelectRecv, 0,
-		emptyC3, go_channel.SelectRecv, 0)
+	idx, _, _, _, _ = channel.NonBlockingSelect3(
+		emptyC1, channel.SelectRecv, 0,
+		emptyC2, channel.SelectRecv, 0,
+		emptyC3, channel.SelectRecv, 0)
 	if idx != 3 {
 		t.Errorf("expected selected index=3 when non-blocking with no available case, got %d", idx)
 	}
 
 	// Close a channel and test receive on closed channel
 	emptyC2.Close()
-	idx, _, val2, _, ok = go_channel.BlockingSelect3(
-		emptyC1, go_channel.SelectRecv, 0,
-		emptyC2, go_channel.SelectRecv, 0,
-		emptyC3, go_channel.SelectRecv, 0)
+	idx, _, val2, _, ok = channel.BlockingSelect3(
+		emptyC1, channel.SelectRecv, 0,
+		emptyC2, channel.SelectRecv, 0,
+		emptyC3, channel.SelectRecv, 0)
 	if idx != 1 {
 		t.Errorf("expected selected index=1 for closed channel, got %d", idx)
 	}
@@ -1168,13 +1168,13 @@ func TestSelect3(t *testing.T) {
 
 // Two non blocking selects should not match up.
 func Test2NBSelectNoProgress(t *testing.T) {
-	c1 := go_channel.NewChannel[int](0)
+	c1 := channel.NewChannel[int](0)
 
 	// Run the receiver loop in a goroutine
 	doneRecv := make(chan struct{})
 	go func() {
 		for {
-			selected, _, _ := go_channel.NonBlockingSelect1(c1, go_channel.SelectRecv, 0)
+			selected, _, _ := channel.NonBlockingSelect1(c1, channel.SelectRecv, 0)
 			if selected {
 				break
 			}
@@ -1186,7 +1186,7 @@ func Test2NBSelectNoProgress(t *testing.T) {
 	doneSend := make(chan struct{})
 	go func() {
 		for {
-			selected, _, _ := go_channel.NonBlockingSelect1(c1, go_channel.SelectSend, 0)
+			selected, _, _ := channel.NonBlockingSelect1(c1, channel.SelectSend, 0)
 			if selected {
 				break
 			}
@@ -1207,7 +1207,7 @@ func Test2NBSelectNoProgress(t *testing.T) {
 }
 
 func TestIter(t *testing.T) {
-	c := go_channel.NewChannel[int](0)
+	c := channel.NewChannel[int](0)
 	expected := make([]int, 0)
 	for i := range 10 {
 		expected = append(expected, i*10)

--- a/model/go_channel/channel_test.go
+++ b/model/go_channel/channel_test.go
@@ -295,7 +295,7 @@ func TestLenCapComparedWithGoChannels(t *testing.T) {
 	// Test special case: nil channel
 	t.Run("NilChannel", func(t *testing.T) {
 		var goChan chan int
-		var ourChan *go_channel.Channel[int]
+		var ourChan go_channel.Channel[int]
 
 		goLen := len(goChan)
 		goCap := cap(goChan)
@@ -363,7 +363,7 @@ func TestBlockingBehavior(t *testing.T) {
 		t.Run("SendToNilBlocks", func(t *testing.T) {
 			// Compare with Go's behavior
 			var goChan chan int
-			var ourChan *go_channel.Channel[int] = nil
+			var ourChan go_channel.Channel[int] = nil
 
 			goBlocked := true
 			ourBlocked := true
@@ -404,7 +404,7 @@ func TestBlockingBehavior(t *testing.T) {
 		t.Run("ReceiveFromNilBlocks", func(t *testing.T) {
 			// Compare with Go's behavior
 			var goChan chan int
-			var ourChan *go_channel.Channel[int] = nil
+			var ourChan go_channel.Channel[int] = nil
 
 			goBlocked := true
 			ourBlocked := true
@@ -600,7 +600,7 @@ func TestPanicComparedWithGoChannels(t *testing.T) {
 		})
 
 		// Test with our channel implementation
-		var ourChan *go_channel.Channel[int]
+		var ourChan go_channel.Channel[int]
 		ourDidPanic, ourMessage := assertPanicsWithMessage(func() {
 			ourChan.Close()
 		})

--- a/model/go_channel/select.go
+++ b/model/go_channel/select.go
@@ -1,0 +1,304 @@
+package go_channel
+
+// This file has the channel select model. This is not used by Goose directly
+// but only by the tests (so the tests trust that this model matches the
+// GooseLang model that is actually used for verification).
+
+type SelectDir uint64
+
+const (
+	SelectSend SelectDir = 0 // case ch <- Send
+	SelectRecv SelectDir = 1 // case <-ch:
+)
+
+// Non-blocking select with 1 case (send or receive)
+// For receive: value parameter is ignored
+// Returns (selected, received_value, ok)
+func NonBlockingSelect1[T any](ch *Channel[T], dir SelectDir, value T) (bool, T, bool) {
+	var zero T
+
+	if dir == SelectSend {
+		selected := ch.TrySend(value, false)
+		return selected, zero, false
+	} else { // SelectRecv
+		selected, recv_val, ok := ch.TryReceive(false)
+		return selected, recv_val, ok
+	}
+}
+
+// Blocking select with 2 cases
+// Returns (caseIndex, received_value1, received_value2, ok)
+func BlockingSelect2[T1, T2 any](
+	ch1 *Channel[T1], dir1 SelectDir, val1 T1,
+	ch2 *Channel[T2], dir2 SelectDir, val2 T2) (uint64, T1, T2, bool) {
+
+	var zero1 T1
+	var zero2 T2
+
+	if dir1 == SelectSend && dir2 == SelectSend {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, false
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, false
+		}
+	} else if dir1 == SelectSend && dir2 == SelectRecv {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, false
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, ok
+		}
+	} else if dir1 == SelectRecv && dir2 == SelectSend {
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, ok
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, false
+		}
+	} else { // both recv
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, ok
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, ok
+		}
+	}
+}
+
+// Non-blocking select with 2 cases
+// Returns (caseIndex, received_value1, received_value2, ok)
+// caseIndex = 2 means no selection
+func NonBlockingSelect2[T1, T2 any](
+	ch1 *Channel[T1], dir1 SelectDir, val1 T1,
+	ch2 *Channel[T2], dir2 SelectDir, val2 T2) (uint64, T1, T2, bool) {
+
+	var zero1 T1
+	var zero2 T2
+
+	if dir1 == SelectSend && dir2 == SelectSend {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, false
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, false
+		default:
+			return 2, zero1, zero2, false
+		}
+	} else if dir1 == SelectSend && dir2 == SelectRecv {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, false
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, ok
+		default:
+			return 2, zero1, zero2, false
+		}
+	} else if dir1 == SelectRecv && dir2 == SelectSend {
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, ok
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, false
+		default:
+			return 2, zero1, zero2, false
+		}
+	} else { // both recv
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, ok
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, ok
+		default:
+			return 2, zero1, zero2, false
+		}
+	}
+}
+
+func BlockingSelect3[T1, T2, T3 any](
+	ch1 *Channel[T1], dir1 SelectDir, val1 T1,
+	ch2 *Channel[T2], dir2 SelectDir, val2 T2,
+	ch3 *Channel[T3], dir3 SelectDir, val3 T3) (uint64, T1, T2, T3, bool) {
+	var zero1 T1
+	var zero2 T2
+	var zero3 T3
+
+	// We need to handle all 8 combinations of send/recv for 3 channels
+	// This is verbose but straightforward
+	if dir1 == SelectSend && dir2 == SelectSend && dir3 == SelectSend {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, zero3, false
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, zero3, false
+		case ch3.ch <- val3:
+			return 2, zero1, zero2, zero3, false
+		}
+	} else if dir1 == SelectSend && dir2 == SelectSend && dir3 == SelectRecv {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, zero3, false
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, zero3, false
+		case v3, ok := <-ch3.ch:
+			return 2, zero1, zero2, v3, ok
+		}
+	} else if dir1 == SelectSend && dir2 == SelectRecv && dir3 == SelectSend {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, zero3, false
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, zero3, ok
+		case ch3.ch <- val3:
+			return 2, zero1, zero2, zero3, false
+		}
+	} else if dir1 == SelectSend && dir2 == SelectRecv && dir3 == SelectRecv {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, zero3, false
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, zero3, ok
+		case v3, ok := <-ch3.ch:
+			return 2, zero1, zero2, v3, ok
+		}
+	} else if dir1 == SelectRecv && dir2 == SelectSend && dir3 == SelectSend {
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, zero3, ok
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, zero3, false
+		case ch3.ch <- val3:
+			return 2, zero1, zero2, zero3, false
+		}
+	} else if dir1 == SelectRecv && dir2 == SelectSend && dir3 == SelectRecv {
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, zero3, ok
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, zero3, false
+		case v3, ok := <-ch3.ch:
+			return 2, zero1, zero2, v3, ok
+		}
+	} else if dir1 == SelectRecv && dir2 == SelectRecv && dir3 == SelectSend {
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, zero3, ok
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, zero3, ok
+		case ch3.ch <- val3:
+			return 2, zero1, zero2, zero3, false
+		}
+	} else { // all recv
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, zero3, ok
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, zero3, ok
+		case v3, ok := <-ch3.ch:
+			return 2, zero1, zero2, v3, ok
+		}
+	}
+}
+
+// Non-blocking select with 3 cases
+// Returns (caseIndex, received_value1, received_value2, received_value3, ok)
+// caseIndex = 3 means no selection
+func NonBlockingSelect3[T1, T2, T3 any](
+	ch1 *Channel[T1], dir1 SelectDir, val1 T1,
+	ch2 *Channel[T2], dir2 SelectDir, val2 T2,
+	ch3 *Channel[T3], dir3 SelectDir, val3 T3) (uint64, T1, T2, T3, bool) {
+	var zero1 T1
+	var zero2 T2
+	var zero3 T3
+
+	// We need to handle all 8 combinations of send/recv for 3 channels
+	if dir1 == SelectSend && dir2 == SelectSend && dir3 == SelectSend {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, zero3, false
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, zero3, false
+		case ch3.ch <- val3:
+			return 2, zero1, zero2, zero3, false
+		default:
+			return 3, zero1, zero2, zero3, false
+		}
+	} else if dir1 == SelectSend && dir2 == SelectSend && dir3 == SelectRecv {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, zero3, false
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, zero3, false
+		case v3, ok := <-ch3.ch:
+			return 2, zero1, zero2, v3, ok
+		default:
+			return 3, zero1, zero2, zero3, false
+		}
+	} else if dir1 == SelectSend && dir2 == SelectRecv && dir3 == SelectSend {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, zero3, false
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, zero3, ok
+		case ch3.ch <- val3:
+			return 2, zero1, zero2, zero3, false
+		default:
+			return 3, zero1, zero2, zero3, false
+		}
+	} else if dir1 == SelectSend && dir2 == SelectRecv && dir3 == SelectRecv {
+		select {
+		case ch1.ch <- val1:
+			return 0, zero1, zero2, zero3, false
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, zero3, ok
+		case v3, ok := <-ch3.ch:
+			return 2, zero1, zero2, v3, ok
+		default:
+			return 3, zero1, zero2, zero3, false
+		}
+	} else if dir1 == SelectRecv && dir2 == SelectSend && dir3 == SelectSend {
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, zero3, ok
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, zero3, false
+		case ch3.ch <- val3:
+			return 2, zero1, zero2, zero3, false
+		default:
+			return 3, zero1, zero2, zero3, false
+		}
+	} else if dir1 == SelectRecv && dir2 == SelectSend && dir3 == SelectRecv {
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, zero3, ok
+		case ch2.ch <- val2:
+			return 1, zero1, zero2, zero3, false
+		case v3, ok := <-ch3.ch:
+			return 2, zero1, zero2, v3, ok
+		default:
+			return 3, zero1, zero2, zero3, false
+		}
+	} else if dir1 == SelectRecv && dir2 == SelectRecv && dir3 == SelectSend {
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, zero3, ok
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, zero3, ok
+		case ch3.ch <- val3:
+			return 2, zero1, zero2, zero3, false
+		default:
+			return 3, zero1, zero2, zero3, false
+		}
+	} else { // all recv
+		select {
+		case v1, ok := <-ch1.ch:
+			return 0, v1, zero2, zero3, ok
+		case v2, ok := <-ch2.ch:
+			return 1, zero1, v2, zero3, ok
+		case v3, ok := <-ch3.ch:
+			return 2, zero1, zero2, v3, ok
+		default:
+			return 3, zero1, zero2, zero3, false
+		}
+	}
+}

--- a/model/go_channel/select.go
+++ b/model/go_channel/select.go
@@ -14,7 +14,7 @@ const (
 // Non-blocking select with 1 case (send or receive)
 // For receive: value parameter is ignored
 // Returns (selected, received_value, ok)
-func NonBlockingSelect1[T any](ch *Channel[T], dir SelectDir, value T) (bool, T, bool) {
+func NonBlockingSelect1[T any](ch Channel[T], dir SelectDir, value T) (bool, T, bool) {
 	var zero T
 
 	if dir == SelectSend {
@@ -29,38 +29,38 @@ func NonBlockingSelect1[T any](ch *Channel[T], dir SelectDir, value T) (bool, T,
 // Blocking select with 2 cases
 // Returns (caseIndex, received_value1, received_value2, ok)
 func BlockingSelect2[T1, T2 any](
-	ch1 *Channel[T1], dir1 SelectDir, val1 T1,
-	ch2 *Channel[T2], dir2 SelectDir, val2 T2) (uint64, T1, T2, bool) {
+	ch1 Channel[T1], dir1 SelectDir, val1 T1,
+	ch2 Channel[T2], dir2 SelectDir, val2 T2) (uint64, T1, T2, bool) {
 
 	var zero1 T1
 	var zero2 T2
 
 	if dir1 == SelectSend && dir2 == SelectSend {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, false
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, false
 		}
 	} else if dir1 == SelectSend && dir2 == SelectRecv {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, false
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, ok
 		}
 	} else if dir1 == SelectRecv && dir2 == SelectSend {
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, ok
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, false
 		}
 	} else { // both recv
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, ok
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, ok
 		}
 	}
@@ -70,44 +70,44 @@ func BlockingSelect2[T1, T2 any](
 // Returns (caseIndex, received_value1, received_value2, ok)
 // caseIndex = 2 means no selection
 func NonBlockingSelect2[T1, T2 any](
-	ch1 *Channel[T1], dir1 SelectDir, val1 T1,
-	ch2 *Channel[T2], dir2 SelectDir, val2 T2) (uint64, T1, T2, bool) {
+	ch1 Channel[T1], dir1 SelectDir, val1 T1,
+	ch2 Channel[T2], dir2 SelectDir, val2 T2) (uint64, T1, T2, bool) {
 
 	var zero1 T1
 	var zero2 T2
 
 	if dir1 == SelectSend && dir2 == SelectSend {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, false
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, false
 		default:
 			return 2, zero1, zero2, false
 		}
 	} else if dir1 == SelectSend && dir2 == SelectRecv {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, false
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, ok
 		default:
 			return 2, zero1, zero2, false
 		}
 	} else if dir1 == SelectRecv && dir2 == SelectSend {
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, ok
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, false
 		default:
 			return 2, zero1, zero2, false
 		}
 	} else { // both recv
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, ok
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, ok
 		default:
 			return 2, zero1, zero2, false
@@ -116,9 +116,9 @@ func NonBlockingSelect2[T1, T2 any](
 }
 
 func BlockingSelect3[T1, T2, T3 any](
-	ch1 *Channel[T1], dir1 SelectDir, val1 T1,
-	ch2 *Channel[T2], dir2 SelectDir, val2 T2,
-	ch3 *Channel[T3], dir3 SelectDir, val3 T3) (uint64, T1, T2, T3, bool) {
+	ch1 Channel[T1], dir1 SelectDir, val1 T1,
+	ch2 Channel[T2], dir2 SelectDir, val2 T2,
+	ch3 Channel[T3], dir3 SelectDir, val3 T3) (uint64, T1, T2, T3, bool) {
 	var zero1 T1
 	var zero2 T2
 	var zero3 T3
@@ -127,74 +127,74 @@ func BlockingSelect3[T1, T2, T3 any](
 	// This is verbose but straightforward
 	if dir1 == SelectSend && dir2 == SelectSend && dir3 == SelectSend {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, zero3, false
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, zero3, false
-		case ch3.ch <- val3:
+		case ch3 <- val3:
 			return 2, zero1, zero2, zero3, false
 		}
 	} else if dir1 == SelectSend && dir2 == SelectSend && dir3 == SelectRecv {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, zero3, false
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, zero3, false
-		case v3, ok := <-ch3.ch:
+		case v3, ok := <-ch3:
 			return 2, zero1, zero2, v3, ok
 		}
 	} else if dir1 == SelectSend && dir2 == SelectRecv && dir3 == SelectSend {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, zero3, false
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, zero3, ok
-		case ch3.ch <- val3:
+		case ch3 <- val3:
 			return 2, zero1, zero2, zero3, false
 		}
 	} else if dir1 == SelectSend && dir2 == SelectRecv && dir3 == SelectRecv {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, zero3, false
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, zero3, ok
-		case v3, ok := <-ch3.ch:
+		case v3, ok := <-ch3:
 			return 2, zero1, zero2, v3, ok
 		}
 	} else if dir1 == SelectRecv && dir2 == SelectSend && dir3 == SelectSend {
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, zero3, ok
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, zero3, false
-		case ch3.ch <- val3:
+		case ch3 <- val3:
 			return 2, zero1, zero2, zero3, false
 		}
 	} else if dir1 == SelectRecv && dir2 == SelectSend && dir3 == SelectRecv {
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, zero3, ok
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, zero3, false
-		case v3, ok := <-ch3.ch:
+		case v3, ok := <-ch3:
 			return 2, zero1, zero2, v3, ok
 		}
 	} else if dir1 == SelectRecv && dir2 == SelectRecv && dir3 == SelectSend {
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, zero3, ok
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, zero3, ok
-		case ch3.ch <- val3:
+		case ch3 <- val3:
 			return 2, zero1, zero2, zero3, false
 		}
 	} else { // all recv
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, zero3, ok
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, zero3, ok
-		case v3, ok := <-ch3.ch:
+		case v3, ok := <-ch3:
 			return 2, zero1, zero2, v3, ok
 		}
 	}
@@ -204,9 +204,9 @@ func BlockingSelect3[T1, T2, T3 any](
 // Returns (caseIndex, received_value1, received_value2, received_value3, ok)
 // caseIndex = 3 means no selection
 func NonBlockingSelect3[T1, T2, T3 any](
-	ch1 *Channel[T1], dir1 SelectDir, val1 T1,
-	ch2 *Channel[T2], dir2 SelectDir, val2 T2,
-	ch3 *Channel[T3], dir3 SelectDir, val3 T3) (uint64, T1, T2, T3, bool) {
+	ch1 Channel[T1], dir1 SelectDir, val1 T1,
+	ch2 Channel[T2], dir2 SelectDir, val2 T2,
+	ch3 Channel[T3], dir3 SelectDir, val3 T3) (uint64, T1, T2, T3, bool) {
 	var zero1 T1
 	var zero2 T2
 	var zero3 T3
@@ -214,88 +214,88 @@ func NonBlockingSelect3[T1, T2, T3 any](
 	// We need to handle all 8 combinations of send/recv for 3 channels
 	if dir1 == SelectSend && dir2 == SelectSend && dir3 == SelectSend {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, zero3, false
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, zero3, false
-		case ch3.ch <- val3:
+		case ch3 <- val3:
 			return 2, zero1, zero2, zero3, false
 		default:
 			return 3, zero1, zero2, zero3, false
 		}
 	} else if dir1 == SelectSend && dir2 == SelectSend && dir3 == SelectRecv {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, zero3, false
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, zero3, false
-		case v3, ok := <-ch3.ch:
+		case v3, ok := <-ch3:
 			return 2, zero1, zero2, v3, ok
 		default:
 			return 3, zero1, zero2, zero3, false
 		}
 	} else if dir1 == SelectSend && dir2 == SelectRecv && dir3 == SelectSend {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, zero3, false
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, zero3, ok
-		case ch3.ch <- val3:
+		case ch3 <- val3:
 			return 2, zero1, zero2, zero3, false
 		default:
 			return 3, zero1, zero2, zero3, false
 		}
 	} else if dir1 == SelectSend && dir2 == SelectRecv && dir3 == SelectRecv {
 		select {
-		case ch1.ch <- val1:
+		case ch1 <- val1:
 			return 0, zero1, zero2, zero3, false
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, zero3, ok
-		case v3, ok := <-ch3.ch:
+		case v3, ok := <-ch3:
 			return 2, zero1, zero2, v3, ok
 		default:
 			return 3, zero1, zero2, zero3, false
 		}
 	} else if dir1 == SelectRecv && dir2 == SelectSend && dir3 == SelectSend {
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, zero3, ok
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, zero3, false
-		case ch3.ch <- val3:
+		case ch3 <- val3:
 			return 2, zero1, zero2, zero3, false
 		default:
 			return 3, zero1, zero2, zero3, false
 		}
 	} else if dir1 == SelectRecv && dir2 == SelectSend && dir3 == SelectRecv {
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, zero3, ok
-		case ch2.ch <- val2:
+		case ch2 <- val2:
 			return 1, zero1, zero2, zero3, false
-		case v3, ok := <-ch3.ch:
+		case v3, ok := <-ch3:
 			return 2, zero1, zero2, v3, ok
 		default:
 			return 3, zero1, zero2, zero3, false
 		}
 	} else if dir1 == SelectRecv && dir2 == SelectRecv && dir3 == SelectSend {
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, zero3, ok
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, zero3, ok
-		case ch3.ch <- val3:
+		case ch3 <- val3:
 			return 2, zero1, zero2, zero3, false
 		default:
 			return 3, zero1, zero2, zero3, false
 		}
 	} else { // all recv
 		select {
-		case v1, ok := <-ch1.ch:
+		case v1, ok := <-ch1:
 			return 0, v1, zero2, zero3, ok
-		case v2, ok := <-ch2.ch:
+		case v2, ok := <-ch2:
 			return 1, zero1, v2, zero3, ok
-		case v3, ok := <-ch3.ch:
+		case v3, ok := <-ch3:
 			return 2, zero1, zero2, v3, ok
 		default:
 			return 3, zero1, zero2, zero3, false


### PR DESCRIPTION
Port all of our current tests of the model back to Go channels, using the same syntax.