### PR TITLE
Prioritize interpreting `x.m` as `(&x).m` shorthand

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -523,23 +523,20 @@ func (ctx *Ctx) selectorExpr(e *ast.SelectorExpr) glang.Expr {
 		// 2*2 cases: receiver type could be (T) or (*T), and e.X type
 		// (including embedded fields) could be (T) or (*T).
 
-		f := ctx.info.ObjectOf(e.Sel).(*types.Func)
-		receiver := ctx.expr(e.X)
+		f := selection.Obj().(*types.Func)
 		receiverType := types.Unalias(ctx.typeOf(e.X))
-		typeExpr := ctx.glangType(e.X, receiverType)
+		receiver := ctx.expr(e.X)
 		methodExpr := glang.StringLiteral{Value: e.Sel.Name}
 
-		// figure out if this is shorthand for (&x).m().
-		methodReceiverType := types.Unalias(f.Signature().Recv().Type())
-		if p, ok := methodReceiverType.(*types.Pointer); ok {
-			if types.Identical(p.Elem(), receiverType) {
-				if !ctx.info.Types[e.X].Addressable() {
-					ctx.nope(e.X, "x is not addressable but want (&x).m")
-				}
+		// If x is addressable and &x's method set contains m, x.m() is shorthand for (&x).m().
+		if ctx.info.Types[e.X].Addressable() {
+			ptrType := types.NewPointer(receiverType)
+			if obj, _, _ := types.LookupFieldOrMethod(ptrType, false, f.Pkg(), f.Name()); obj != nil {
+				receiverType = ptrType
 				receiver = ctx.exprAddr(e.X)
-				typeExpr = ctx.glangType(e.X, types.NewPointer(receiverType))
 			}
 		}
+		typeExpr := ctx.glangType(e.X, receiverType)
 
 		return glang.NewCallExpr(glang.VerbatimExpr("MethodResolve"), typeExpr, methodExpr, receiver)
 	}

--- a/testdata/examples/append_log/append_log.gold.v
+++ b/testdata/examples/append_log/append_log.gold.v
@@ -28,10 +28,10 @@ Definition Log__mkHdrⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     (FuncResolve marshal.NewEnc [] #()) "$a0") in
     do:  ("enc" <-[marshal.Enc] "$r0");;;
     do:  (let: "$a0" := (![go.uint64] (StructFieldRef Log "sz"%go (![go.PointerType Log] "log"))) in
-    (MethodResolve marshal.Enc "PutInt"%go (![marshal.Enc] "enc")) "$a0");;;
+    (MethodResolve (go.PointerType marshal.Enc) "PutInt"%go "enc") "$a0");;;
     do:  (let: "$a0" := (![go.uint64] (StructFieldRef Log "diskSz"%go (![go.PointerType Log] "log"))) in
-    (MethodResolve marshal.Enc "PutInt"%go (![marshal.Enc] "enc")) "$a0");;;
-    return: ((MethodResolve marshal.Enc "Finish"%go (![marshal.Enc] "enc")) #())).
+    (MethodResolve (go.PointerType marshal.Enc) "PutInt"%go "enc") "$a0");;;
+    return: ((MethodResolve (go.PointerType marshal.Enc) "Finish"%go "enc") #())).
 
 (* go: append_log.go:29:17 *)
 Definition Log__writeHdrⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
@@ -74,10 +74,10 @@ Definition Openⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val 
     (FuncResolve marshal.NewDec [] #()) "$a0") in
     do:  ("dec" <-[marshal.Dec] "$r0");;;
     let: "sz" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
-    let: "$r0" := ((MethodResolve marshal.Dec "GetInt"%go (![marshal.Dec] "dec")) #()) in
+    let: "$r0" := ((MethodResolve (go.PointerType marshal.Dec) "GetInt"%go "dec") #()) in
     do:  ("sz" <-[go.uint64] "$r0");;;
     let: "diskSz" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
-    let: "$r0" := ((MethodResolve marshal.Dec "GetInt"%go (![marshal.Dec] "dec")) #()) in
+    let: "$r0" := ((MethodResolve (go.PointerType marshal.Dec) "GetInt"%go "dec") #()) in
     do:  ("diskSz" <-[go.uint64] "$r0");;;
     return: (GoAlloc Log (let: "$v0" := (GoAlloc sync.Mutex (GoZeroVal sync.Mutex #())) in
      let: "$v1" := (![go.uint64] "sz") in

--- a/testdata/examples/logging2/logging2.gold.v
+++ b/testdata/examples/logging2/logging2.gold.v
@@ -37,7 +37,7 @@ Definition Log__writeHdrⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContex
     do:  ("hdr" <-[go.SliceType go.byte] "$r0");;;
     do:  (let: "$a0" := (![go.SliceType go.byte] "hdr") in
     let: "$a1" := (![go.uint64] "len") in
-    (MethodResolve binary.littleEndian "PutUint64"%go (![binary.littleEndian] (GlobalVarAddr binary.LittleEndian #()))) "$a0" "$a1");;;
+    (MethodResolve (go.PointerType binary.littleEndian) "PutUint64"%go (GlobalVarAddr binary.LittleEndian #())) "$a0" "$a1");;;
     do:  (let: "$a0" := LOGCOMMIT in
     let: "$a1" := (![go.SliceType go.byte] "hdr") in
     (FuncResolve disk.Write [] #()) "$a0" "$a1");;;
@@ -58,7 +58,7 @@ Definition Initⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val 
     CompositeLiteral Log (LiteralValue [KeyedElement (Some (KeyField "logLock"%go)) (ElementExpression (go.PointerType sync.Mutex) "$v0"); KeyedElement (Some (KeyField "memLock"%go)) (ElementExpression (go.PointerType sync.Mutex) "$v1"); KeyedElement (Some (KeyField "logSz"%go)) (ElementExpression go.uint64 "$v2"); KeyedElement (Some (KeyField "memLog"%go)) (ElementExpression (go.PointerType (go.SliceType disk.Block)) "$v3"); KeyedElement (Some (KeyField "memLen"%go)) (ElementExpression (go.PointerType go.uint64) "$v4"); KeyedElement (Some (KeyField "memTxnNxt"%go)) (ElementExpression (go.PointerType go.uint64) "$v5"); KeyedElement (Some (KeyField "logTxnNxt"%go)) (ElementExpression (go.PointerType go.uint64) "$v6")])) in
     do:  ("log" <-[Log] "$r0");;;
     do:  (let: "$a0" := #(W64 0) in
-    (MethodResolve Log "writeHdr"%go (![Log] "log")) "$a0");;;
+    (MethodResolve (go.PointerType Log) "writeHdr"%go "log") "$a0");;;
     return: (![Log] "log")).
 
 (* go: logging2.go:46:16 *)
@@ -71,7 +71,7 @@ Definition Log__readHdrⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext
     do:  ("hdr" <-[disk.Block] "$r0");;;
     let: "disklen" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (let: "$a0" := (![disk.Block] "hdr") in
-    (MethodResolve binary.littleEndian "Uint64"%go (![binary.littleEndian] (GlobalVarAddr binary.LittleEndian #()))) "$a0") in
+    (MethodResolve (go.PointerType binary.littleEndian) "Uint64"%go (GlobalVarAddr binary.LittleEndian #())) "$a0") in
     do:  ("disklen" <-[go.uint64] "$r0");;;
     return: (![go.uint64] "disklen")).
 
@@ -104,11 +104,11 @@ Definition Log__Readⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} :
     exception_do (let: "log" := (GoAlloc Log "log") in
     do:  ((MethodResolve (go.PointerType sync.Mutex) "Lock"%go (![go.PointerType sync.Mutex] (StructFieldRef Log "logLock"%go "log"))) #());;;
     let: "disklen" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
-    let: "$r0" := ((MethodResolve Log "readHdr"%go (![Log] "log")) #()) in
+    let: "$r0" := ((MethodResolve (go.PointerType Log) "readHdr"%go "log") #()) in
     do:  ("disklen" <-[go.uint64] "$r0");;;
     let: "blks" := (GoAlloc (go.SliceType disk.Block) (GoZeroVal (go.SliceType disk.Block) #())) in
     let: "$r0" := (let: "$a0" := (![go.uint64] "disklen") in
-    (MethodResolve Log "readBlocks"%go (![Log] "log")) "$a0") in
+    (MethodResolve (go.PointerType Log) "readBlocks"%go "log") "$a0") in
     do:  ("blks" <-[go.SliceType disk.Block] "$r0");;;
     do:  ((MethodResolve (go.PointerType sync.Mutex) "Unlock"%go (![go.PointerType sync.Mutex] (StructFieldRef Log "logLock"%go "log"))) #());;;
     return: (![go.SliceType disk.Block] "blks")).
@@ -179,7 +179,7 @@ Definition Log__diskAppendWaitⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobal
     let: "txn" := (GoAlloc go.uint64 "txn") in
     (for: (λ: <>, #true); (λ: <>, #()) := λ: <>,
       let: "logtxn" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
-      let: "$r0" := ((MethodResolve Log "readLogTxnNxt"%go (![Log] "log")) #()) in
+      let: "$r0" := ((MethodResolve (go.PointerType Log) "readLogTxnNxt"%go "log") #()) in
       do:  ("logtxn" <-[go.uint64] "$r0");;;
       (if: Convert go.untyped_bool go.bool ((![go.uint64] "txn") <⟨go.uint64⟩ (![go.uint64] "logtxn"))
       then break: #()
@@ -195,7 +195,7 @@ Definition Log__Appendⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext}
     let: "txn" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "ok" := (GoAlloc go.bool (GoZeroVal go.bool #())) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![go.SliceType disk.Block] "l") in
-    (MethodResolve Log "memAppend"%go (![Log] "log")) "$a0") in
+    (MethodResolve (go.PointerType Log) "memAppend"%go "log") "$a0") in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
     do:  ("ok" <-[go.bool] "$r0");;;
@@ -203,7 +203,7 @@ Definition Log__Appendⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext}
     (if: ![go.bool] "ok"
     then
       do:  (let: "$a0" := (![go.uint64] "txn") in
-      (MethodResolve Log "diskAppendWait"%go (![Log] "log")) "$a0")
+      (MethodResolve (go.PointerType Log) "diskAppendWait"%go "log") "$a0")
     else do:  #());;;
     return: (![go.bool] "ok")).
 
@@ -235,7 +235,7 @@ Definition Log__diskAppendⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalCont
     exception_do (let: "log" := (GoAlloc Log "log") in
     do:  ((MethodResolve (go.PointerType sync.Mutex) "Lock"%go (![go.PointerType sync.Mutex] (StructFieldRef Log "logLock"%go "log"))) #());;;
     let: "disklen" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
-    let: "$r0" := ((MethodResolve Log "readHdr"%go (![Log] "log")) #()) in
+    let: "$r0" := ((MethodResolve (go.PointerType Log) "readHdr"%go "log") #()) in
     do:  ("disklen" <-[go.uint64] "$r0");;;
     do:  ((MethodResolve (go.PointerType sync.Mutex) "Lock"%go (![go.PointerType sync.Mutex] (StructFieldRef Log "memLock"%go "log"))) #());;;
     let: "memlen" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
@@ -254,9 +254,9 @@ Definition Log__diskAppendⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalCont
     do:  ((MethodResolve (go.PointerType sync.Mutex) "Unlock"%go (![go.PointerType sync.Mutex] (StructFieldRef Log "memLock"%go "log"))) #());;;
     do:  (let: "$a0" := (![go.SliceType disk.Block] "blks") in
     let: "$a1" := (![go.uint64] "disklen") in
-    (MethodResolve Log "writeBlocks"%go (![Log] "log")) "$a0" "$a1");;;
+    (MethodResolve (go.PointerType Log) "writeBlocks"%go "log") "$a0" "$a1");;;
     do:  (let: "$a0" := (![go.uint64] "memlen") in
-    (MethodResolve Log "writeHdr"%go (![Log] "log")) "$a0");;;
+    (MethodResolve (go.PointerType Log) "writeHdr"%go "log") "$a0");;;
     let: "$r0" := (![go.uint64] "memnxt") in
     do:  ((![go.PointerType go.uint64] (StructFieldRef Log "logTxnNxt"%go "log")) <-[go.uint64] "$r0");;;
     do:  ((MethodResolve (go.PointerType sync.Mutex) "Unlock"%go (![go.PointerType sync.Mutex] (StructFieldRef Log "logLock"%go "log"))) #());;;
@@ -267,7 +267,7 @@ Definition Log__Loggerⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext}
   λ: "log" <>,
     exception_do (let: "log" := (GoAlloc Log "log") in
     (for: (λ: <>, #true); (λ: <>, #()) := λ: <>,
-      do:  ((MethodResolve Log "diskAppend"%go (![Log] "log")) #()));;;
+      do:  ((MethodResolve (go.PointerType Log) "diskAppend"%go "log") #()));;;
     return: #()).
 
 (* XXX wait if cannot reserve space in log
@@ -352,7 +352,7 @@ Definition Txn__Commitⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext}
       do:  ((![go.PointerType (go.SliceType disk.Block)] "blks") <-[go.SliceType disk.Block] "$r0")));;;
     let: "ok" := (GoAlloc go.bool (GoZeroVal go.bool #())) in
     let: "$r0" := (let: "$a0" := (![go.SliceType disk.Block] (![go.PointerType (go.SliceType disk.Block)] "blks")) in
-    (MethodResolve Log "Append"%go (![Log] (![go.PointerType Log] (StructFieldRef Txn "log"%go "txn")))) "$a0") in
+    (MethodResolve (go.PointerType Log) "Append"%go (![go.PointerType Log] (StructFieldRef Txn "log"%go "txn"))) "$a0") in
     do:  ("ok" <-[go.bool] "$r0");;;
     return: (![go.bool] "ok")).
 

--- a/testdata/examples/semantics/semantics.gold.v
+++ b/testdata/examples/semantics/semantics.gold.v
@@ -1135,7 +1135,7 @@ Definition testForLoopWaitⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalCont
     CompositeLiteral LoopStruct (LiteralValue [KeyedElement (Some (KeyField "loopNext"%go)) (ElementExpression (go.PointerType go.uint64) "$v0")])) in
     do:  ("ls" <-[LoopStruct] "$r0");;;
     do:  (let: "$a0" := #(W64 3) in
-    (MethodResolve LoopStruct "forLoopWait"%go (![LoopStruct] "ls")) "$a0");;;
+    (MethodResolve (go.PointerType LoopStruct) "forLoopWait"%go "ls") "$a0");;;
     return: ((![go.uint64] (![go.PointerType go.uint64] (StructFieldRef LoopStruct "loopNext"%go "ls"))) =⟨go.uint64⟩ #(W64 4))).
 
 (* go: loops.go:59:6 *)
@@ -2512,7 +2512,7 @@ Definition intToBlockⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     do:  ("b" <-[go.SliceType go.byte] "$r0");;;
     do:  (let: "$a0" := (![go.SliceType go.byte] "b") in
     let: "$a1" := (![go.uint64] "a") in
-    (MethodResolve binary.littleEndian "PutUint64"%go (![binary.littleEndian] (GlobalVarAddr binary.LittleEndian #()))) "$a0" "$a1");;;
+    (MethodResolve (go.PointerType binary.littleEndian) "PutUint64"%go (GlobalVarAddr binary.LittleEndian #())) "$a0" "$a1");;;
     return: (![go.SliceType go.byte] "b")).
 
 (* go: wal.go:30:6 *)
@@ -2520,7 +2520,7 @@ Definition blockToIntⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
   λ: "v",
     exception_do (let: "v" := (GoAlloc disk.Block "v") in
     return: (let: "$a0" := (![disk.Block] "v") in
-     (MethodResolve binary.littleEndian "Uint64"%go (![binary.littleEndian] (GlobalVarAddr binary.LittleEndian #()))) "$a0")).
+     (MethodResolve (go.PointerType binary.littleEndian) "Uint64"%go (GlobalVarAddr binary.LittleEndian #())) "$a0")).
 
 (* New initializes a fresh log
 
@@ -2584,16 +2584,16 @@ Definition Log__unlockⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext}
 Definition Log__BeginTxnⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: "l" <>,
     exception_do (let: "l" := (GoAlloc Log "l") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "length" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (![go.uint64] (![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l"))) in
     do:  ("length" <-[go.uint64] "$r0");;;
     (if: Convert go.untyped_bool go.bool ((![go.uint64] "length") =⟨go.uint64⟩ #(W64 0))
     then
-      do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+      do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
       return: (#true)
     else do:  #());;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     return: (#false)).
 
 (* Read from the logical disk.
@@ -2605,7 +2605,7 @@ Definition Log__Readⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} :
   λ: "l" "a",
     exception_do (let: "l" := (GoAlloc Log "l") in
     let: "a" := (GoAlloc go.uint64 "a") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "ok" := (GoAlloc go.bool (GoZeroVal go.bool #())) in
     let: "v" := (GoAlloc disk.Block (GoZeroVal disk.Block #())) in
     let: ("$ret0", "$ret1") := (map.lookup2 go.uint64 disk.Block (![go.MapType go.uint64 disk.Block] (StructFieldRef Log "cache"%go "l")) (![go.uint64] "a")) in
@@ -2615,10 +2615,10 @@ Definition Log__Readⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} :
     do:  ("ok" <-[go.bool] "$r1");;;
     (if: ![go.bool] "ok"
     then
-      do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+      do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
       return: (![disk.Block] "v")
     else do:  #());;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     let: "dv" := (GoAlloc disk.Block (GoZeroVal disk.Block #())) in
     let: "$r0" := (let: "$a0" := (logLength +⟨go.uint64⟩ (![go.uint64] "a")) in
     (MethodResolve disk.Disk "Read"%go (![disk.Disk] (StructFieldRef Log "d"%go "l"))) "$a0") in
@@ -2642,7 +2642,7 @@ Definition Log__Writeⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     exception_do (let: "l" := (GoAlloc Log "l") in
     let: "v" := (GoAlloc disk.Block "v") in
     let: "a" := (GoAlloc go.uint64 "a") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "length" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (![go.uint64] (![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l"))) in
     do:  ("length" <-[go.uint64] "$r0");;;
@@ -2668,7 +2668,7 @@ Definition Log__Writeⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     do:  (map.insert go.uint64 (![go.MapType go.uint64 disk.Block] (StructFieldRef Log "cache"%go "l")) (![go.uint64] "a") "$r0");;;
     let: "$r0" := ((![go.uint64] "length") +⟨go.uint64⟩ #(W64 1)) in
     do:  ((![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l")) <-[go.uint64] "$r0");;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     return: #()).
 
 (* Commit the current transaction.
@@ -2677,11 +2677,11 @@ Definition Log__Writeⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
 Definition Log__Commitⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: "l" <>,
     exception_do (let: "l" := (GoAlloc Log "l") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "length" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (![go.uint64] (![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l"))) in
     do:  ("length" <-[go.uint64] "$r0");;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     let: "header" := (GoAlloc disk.Block (GoZeroVal disk.Block #())) in
     let: "$r0" := (let: "$a0" := (![go.uint64] "length") in
     (FuncResolve intToBlock [] #()) "$a0") in
@@ -2766,7 +2766,7 @@ Definition clearLogⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : 
 Definition Log__Applyⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: "l" <>,
     exception_do (let: "l" := (GoAlloc Log "l") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "length" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (![go.uint64] (![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l"))) in
     do:  ("length" <-[go.uint64] "$r0");;;
@@ -2777,7 +2777,7 @@ Definition Log__Applyⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     (FuncResolve clearLog [] #()) "$a0");;;
     let: "$r0" := #(W64 0) in
     do:  ((![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l")) <-[go.uint64] "$r0");;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     return: #()).
 
 (* Open recovers the log following a crash or shutdown
@@ -2829,27 +2829,27 @@ Definition disabled_testWalⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalCon
     let: "lg" := (GoAlloc Log (GoZeroVal Log #())) in
     let: "$r0" := ((FuncResolve New [] #()) #()) in
     do:  ("lg" <-[Log] "$r0");;;
-    (if: (MethodResolve Log "BeginTxn"%go (![Log] "lg")) #()
+    (if: (MethodResolve (go.PointerType Log) "BeginTxn"%go "lg") #()
     then
       do:  (let: "$a0" := #(W64 2) in
       let: "$a1" := (let: "$a0" := #(W64 11) in
       (FuncResolve intToBlock [] #()) "$a0") in
-      (MethodResolve Log "Write"%go (![Log] "lg")) "$a0" "$a1")
+      (MethodResolve (go.PointerType Log) "Write"%go "lg") "$a0" "$a1")
     else do:  #());;;
     let: "$r0" := ((![go.bool] "ok") && ((let: "$a0" := (let: "$a0" := #(W64 2) in
-    (MethodResolve Log "Read"%go (![Log] "lg")) "$a0") in
+    (MethodResolve (go.PointerType Log) "Read"%go "lg") "$a0") in
     (FuncResolve blockToInt [] #()) "$a0") =⟨go.uint64⟩ #(W64 11))) in
     do:  ("ok" <-[go.bool] "$r0");;;
     let: "$r0" := ((![go.bool] "ok") && ((let: "$a0" := (let: "$a0" := #(W64 0) in
     (MethodResolve disk.Disk "Read"%go (![disk.Disk] (StructFieldRef Log "d"%go "lg"))) "$a0") in
     (FuncResolve blockToInt [] #()) "$a0") =⟨go.uint64⟩ #(W64 0))) in
     do:  ("ok" <-[go.bool] "$r0");;;
-    do:  ((MethodResolve Log "Commit"%go (![Log] "lg")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "Commit"%go "lg") #());;;
     let: "$r0" := ((![go.bool] "ok") && ((let: "$a0" := (let: "$a0" := #(W64 0) in
     (MethodResolve disk.Disk "Read"%go (![disk.Disk] (StructFieldRef Log "d"%go "lg"))) "$a0") in
     (FuncResolve blockToInt [] #()) "$a0") =⟨go.uint64⟩ #(W64 1))) in
     do:  ("ok" <-[go.bool] "$r0");;;
-    do:  ((MethodResolve Log "Apply"%go (![Log] "lg")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "Apply"%go "lg") #());;;
     let: "$r0" := ((![go.bool] "ok") && ((![go.uint64] (![go.PointerType go.uint64] (StructFieldRef Log "length"%go "lg"))) =⟨go.uint64⟩ #(W64 0))) in
     do:  ("ok" <-[go.bool] "$r0");;;
     return: (![go.bool] "ok")).

--- a/testdata/examples/simpledb/simpledb.gold.v
+++ b/testdata/examples/simpledb/simpledb.gold.v
@@ -143,7 +143,7 @@ Definition DecodeUInt64ⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext
     else do:  #());;;
     let: "n" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (let: "$a0" := (![go.SliceType go.byte] "p") in
-    (MethodResolve binary.littleEndian "Uint64"%go (![binary.littleEndian] (GlobalVarAddr binary.LittleEndian #()))) "$a0") in
+    (MethodResolve (go.PointerType binary.littleEndian) "Uint64"%go (GlobalVarAddr binary.LittleEndian #())) "$a0") in
     do:  ("n" <-[go.uint64] "$r0");;;
     return: (![go.uint64] "n", #(W64 8))).
 
@@ -296,7 +296,7 @@ Definition readValueⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} :
     do:  ("startBuf" <-[go.SliceType go.byte] "$r0");;;
     let: "totalBytes" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (let: "$a0" := (![go.SliceType go.byte] "startBuf") in
-    (MethodResolve binary.littleEndian "Uint64"%go (![binary.littleEndian] (GlobalVarAddr binary.LittleEndian #()))) "$a0") in
+    (MethodResolve (go.PointerType binary.littleEndian) "Uint64"%go (GlobalVarAddr binary.LittleEndian #())) "$a0") in
     do:  ("totalBytes" <-[go.uint64] "$r0");;;
     let: "buf" := (GoAlloc (go.SliceType go.byte) (GoZeroVal (go.SliceType go.byte) #())) in
     let: "$r0" := (let: "$s" := (![go.SliceType go.byte] "startBuf") in
@@ -473,7 +473,7 @@ Definition EncodeUInt64ⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext
     do:  ("tmp" <-[go.SliceType go.byte] "$r0");;;
     do:  (let: "$a0" := (![go.SliceType go.byte] "tmp") in
     let: "$a1" := (![go.uint64] "x") in
-    (MethodResolve binary.littleEndian "PutUint64"%go (![binary.littleEndian] (GlobalVarAddr binary.LittleEndian #()))) "$a0" "$a1");;;
+    (MethodResolve (go.PointerType binary.littleEndian) "PutUint64"%go (GlobalVarAddr binary.LittleEndian #())) "$a0" "$a1");;;
     let: "p2" := (GoAlloc (go.SliceType go.byte) (GoZeroVal (go.SliceType go.byte) #())) in
     let: "$r0" := (let: "$a0" := (![go.SliceType go.byte] "p") in
     let: "$a1" := (![go.SliceType go.byte] "tmp") in

--- a/testdata/examples/unittest/generics/generics.gold.v
+++ b/testdata/examples/unittest/generics/generics.gold.v
@@ -103,7 +103,7 @@ Definition useBoxGetⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} :
     let: "$r0" := (let: "$a0" := #(W64 42) in
     (FuncResolve makeGenericBox [go.uint64] #()) "$a0") in
     do:  ("x" <-[Box go.uint64] "$r0");;;
-    return: ((MethodResolve (Box go.uint64) "Get"%go (![Box go.uint64] "x")) #())).
+    return: ((MethodResolve (go.PointerType (Box go.uint64)) "Get"%go "x") #())).
 
 (* go: generics.go:47:6 *)
 Definition useContainerⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -1294,14 +1294,14 @@ Definition useEmbeddedValFieldⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobal
 Definition useEmbeddedMethodⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: "d",
     exception_do (let: "d" := (GoAlloc embedD "d") in
-    return: (((MethodResolve embedD "Bar"%go (![embedD] "d")) #()) =⟨go.string⟩ ((MethodResolve (go.PointerType embedA) "Bar"%go (StructFieldRef embedB "embedA"%go (![go.PointerType embedB] (StructFieldRef embedC "embedB"%go (StructFieldRef embedD "embedC"%go "d"))))) #()))).
+    return: (((MethodResolve (go.PointerType embedD) "Bar"%go "d") #()) =⟨go.string⟩ ((MethodResolve (go.PointerType embedA) "Bar"%go (StructFieldRef embedB "embedA"%go (![go.PointerType embedB] (StructFieldRef embedC "embedB"%go (StructFieldRef embedD "embedC"%go "d"))))) #()))).
 
 (* go: embedded.go:64:6 *)
 Definition useEmbeddedMethod2ⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: "d",
     exception_do (let: "d" := (GoAlloc embedD "d") in
-    do:  ((MethodResolve embedD "Car"%go (![embedD] "d")) #());;;
-    return: (((MethodResolve embedD "Foo"%go (![embedD] "d")) #()) =⟨go.string⟩ ((MethodResolve (go.PointerType embedB) "Foo"%go (![go.PointerType embedB] (StructFieldRef embedC "embedB"%go (StructFieldRef embedD "embedC"%go "d")))) #()))).
+    do:  ((MethodResolve (go.PointerType embedD) "Car"%go "d") #());;;
+    return: (((MethodResolve (go.PointerType embedD) "Foo"%go "d") #()) =⟨go.string⟩ ((MethodResolve (go.PointerType embedB) "Foo"%go (![go.PointerType embedB] (StructFieldRef embedC "embedB"%go (StructFieldRef embedD "embedC"%go "d")))) #()))).
 
 (* go: empty_functions.go:3:6 *)
 Definition emptyⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
@@ -2325,7 +2325,7 @@ Definition R__recurMethodⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalConte
 Definition RecursiveEmbedded__recurEmbeddedMethodⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: "r" <>,
     exception_do (let: "r" := (GoAlloc (go.PointerType RecursiveEmbedded) "r") in
-    do:  ((MethodResolve Other "recurEmbeddedMethod"%go (![Other] (StructFieldRef RecursiveEmbedded "Other"%go (![go.PointerType RecursiveEmbedded] "r")))) #());;;
+    do:  ((MethodResolve (go.PointerType Other) "recurEmbeddedMethod"%go (StructFieldRef RecursiveEmbedded "Other"%go (![go.PointerType RecursiveEmbedded] "r"))) #());;;
     return: #()).
 
 (* go: renamedImport.go:7:6 *)
@@ -2741,7 +2741,7 @@ Definition UseAddⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : va
     do:  ("c" <-[Point] "$r0");;;
     let: "r" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (let: "$a0" := #(W64 4) in
-    (MethodResolve Point "Add"%go (![Point] "c")) "$a0") in
+    (MethodResolve (go.PointerType Point) "Add"%go "c") "$a0") in
     do:  ("r" <-[go.uint64] "$r0");;;
     return: (![go.uint64] "r")).
 

--- a/testdata/examples/wal/wal.gold.v
+++ b/testdata/examples/wal/wal.gold.v
@@ -41,7 +41,7 @@ Definition intToBlockⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     do:  ("b" <-[go.SliceType go.byte] "$r0");;;
     do:  (let: "$a0" := (![go.SliceType go.byte] "b") in
     let: "$a1" := (![go.uint64] "a") in
-    (MethodResolve binary.littleEndian "PutUint64"%go (![binary.littleEndian] (GlobalVarAddr binary.LittleEndian #()))) "$a0" "$a1");;;
+    (MethodResolve (go.PointerType binary.littleEndian) "PutUint64"%go (GlobalVarAddr binary.LittleEndian #())) "$a0" "$a1");;;
     return: (![go.SliceType go.byte] "b")).
 
 (* go: log.go:30:6 *)
@@ -50,7 +50,7 @@ Definition blockToIntⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     exception_do (let: "v" := (GoAlloc disk.Block "v") in
     let: "a" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (let: "$a0" := (![disk.Block] "v") in
-    (MethodResolve binary.littleEndian "Uint64"%go (![binary.littleEndian] (GlobalVarAddr binary.LittleEndian #()))) "$a0") in
+    (MethodResolve (go.PointerType binary.littleEndian) "Uint64"%go (GlobalVarAddr binary.LittleEndian #())) "$a0") in
     do:  ("a" <-[go.uint64] "$r0");;;
     return: (![go.uint64] "a")).
 
@@ -116,16 +116,16 @@ Definition Log__unlockⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext}
 Definition Log__BeginTxnⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: "l" <>,
     exception_do (let: "l" := (GoAlloc Log "l") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "length" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (![go.uint64] (![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l"))) in
     do:  ("length" <-[go.uint64] "$r0");;;
     (if: Convert go.untyped_bool go.bool ((![go.uint64] "length") =⟨go.uint64⟩ #(W64 0))
     then
-      do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+      do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
       return: (#true)
     else do:  #());;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     return: (#false)).
 
 (* Read from the logical disk.
@@ -137,7 +137,7 @@ Definition Log__Readⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} :
   λ: "l" "a",
     exception_do (let: "l" := (GoAlloc Log "l") in
     let: "a" := (GoAlloc go.uint64 "a") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "ok" := (GoAlloc go.bool (GoZeroVal go.bool #())) in
     let: "v" := (GoAlloc disk.Block (GoZeroVal disk.Block #())) in
     let: ("$ret0", "$ret1") := (map.lookup2 go.uint64 disk.Block (![go.MapType go.uint64 disk.Block] (StructFieldRef Log "cache"%go "l")) (![go.uint64] "a")) in
@@ -147,10 +147,10 @@ Definition Log__Readⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} :
     do:  ("ok" <-[go.bool] "$r1");;;
     (if: ![go.bool] "ok"
     then
-      do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+      do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
       return: (![disk.Block] "v")
     else do:  #());;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     let: "dv" := (GoAlloc disk.Block (GoZeroVal disk.Block #())) in
     let: "$r0" := (let: "$a0" := (logLength +⟨go.uint64⟩ (![go.uint64] "a")) in
     (MethodResolve disk.Disk "Read"%go (![disk.Disk] (StructFieldRef Log "d"%go "l"))) "$a0") in
@@ -174,7 +174,7 @@ Definition Log__Writeⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     exception_do (let: "l" := (GoAlloc Log "l") in
     let: "v" := (GoAlloc disk.Block "v") in
     let: "a" := (GoAlloc go.uint64 "a") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "length" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (![go.uint64] (![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l"))) in
     do:  ("length" <-[go.uint64] "$r0");;;
@@ -200,7 +200,7 @@ Definition Log__Writeⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     do:  (map.insert go.uint64 (![go.MapType go.uint64 disk.Block] (StructFieldRef Log "cache"%go "l")) (![go.uint64] "a") "$r0");;;
     let: "$r0" := ((![go.uint64] "length") +⟨go.uint64⟩ #(W64 1)) in
     do:  ((![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l")) <-[go.uint64] "$r0");;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     return: #()).
 
 (* Commit the current transaction.
@@ -209,11 +209,11 @@ Definition Log__Writeⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
 Definition Log__Commitⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: "l" <>,
     exception_do (let: "l" := (GoAlloc Log "l") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "length" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (![go.uint64] (![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l"))) in
     do:  ("length" <-[go.uint64] "$r0");;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     let: "header" := (GoAlloc disk.Block (GoZeroVal disk.Block #())) in
     let: "$r0" := (let: "$a0" := (![go.uint64] "length") in
     (FuncResolve intToBlock [] #()) "$a0") in
@@ -298,7 +298,7 @@ Definition clearLogⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : 
 Definition Log__Applyⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} : val :=
   λ: "l" <>,
     exception_do (let: "l" := (GoAlloc Log "l") in
-    do:  ((MethodResolve Log "lock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "lock"%go "l") #());;;
     let: "length" := (GoAlloc go.uint64 (GoZeroVal go.uint64 #())) in
     let: "$r0" := (![go.uint64] (![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l"))) in
     do:  ("length" <-[go.uint64] "$r0");;;
@@ -309,7 +309,7 @@ Definition Log__Applyⁱᵐᵖˡ {ext : ffi_syntax} {go_gctx : GoGlobalContext} 
     (FuncResolve clearLog [] #()) "$a0");;;
     let: "$r0" := #(W64 0) in
     do:  ((![go.PointerType go.uint64] (StructFieldRef Log "length"%go "l")) <-[go.uint64] "$r0");;;
-    do:  ((MethodResolve Log "unlock"%go (![Log] "l")) #());;;
+    do:  ((MethodResolve (go.PointerType Log) "unlock"%go "l") #());;;
     return: #()).
 
 (* Open recovers the log following a crash or shutdown


### PR DESCRIPTION
The Go spec says:
> If x is [addressable](https://go.dev/ref/spec#Address_operators) and &x's method set contains m, x.m() is shorthand for (&x).m()

This should be interpreted pretty literally: even if `m` is a method on `x`, if it's also a method on `&x`, it should be interpreted as the `&x` method. This makes a non-trivial difference when the method is coming from an embedded field:
```
type inner struct{}

type outer struct {
	inner
	other int
}

func (i inner) do() {}

func test(o outer) {
	o.do()
	// Above does not load `o.other`, but the below does. If there are 
	// concurrent modifications to `o.other`, this can cause data races.
	x := o
	x.do()
}
```